### PR TITLE
Working Travis CI configuration for Actualtime Plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,58 @@
 language: php
-
-env:
-  global:
-    - GLPI_SOURCE="https://github.com/glpi-project/glpi"
-    - PHPUNIT_ARGS="--verbose --debug"
-    - CS=7.2
-  matrix:
-    - GLPI_BRANCH=9.2.1
-    - GLPI_BRANCH=9.2/bugfixes
-    - GLPI_BRANCH=9.3/bugfixes
-    - GLPI_BRANCH=master
-
 php:
   - 5.6
   - 7.0
   - 7.1
   - 7.2
-  - 7.2
   - nightly
 
-allow_failures:
-  - php: nightly
-  - env: GLPI_BRANCH=master
+env:
+  global:
+    - DB=mysql
+  matrix:
+    - GLPIVER=9.4/bugfixes
+    - GLPIVER=9.3/bugfixes
+    - GLPIVER=9.2/bugfixes
+    - GLPIVER=master
 
 before_script:
-  - mysql -u root -e 'create database glpitest;'
-  - git clone --depth=1 $GLPI_SOURCE -b $GLPI_BRANCH ../glpi && cd ../glpi
+  - composer self-update
+  - composer require --dev atoum/atoum
+  - git clone --depth=1 https://github.com/glpi-project/glpi -b $GLPIVER ../glpi && cd ../glpi
   - composer install --no-dev
-  - if [ -e scripts/cliinstall.php ] ; then php scripts/cliinstall.php --db=glpitest --user=root --tests ; fi
-  - if [ -e tools/cliinstall.php ] ; then php tools/cliinstall.php --db=glpitest --user=root --tests ; fi
-  - mv ../GDrive plugins/GDrive
-  - cd plugins/GDrive
-  - composer install
+  - mysql -u root -e 'create database glpitest;'
+  # Both 9.3 and 9.4:
+  - if [[ -f "scripts/cliinstall.php" ]]; then php scripts/cliinstall.php --db=glpitest --user=root --tests; else bin/console glpi:database:install --config-dir=./tests --no-interaction --db-name=glpitest --db-user=root; fi
+  - mv ../actualtime plugins/actualtime
+  - cd plugins/actualtime
+  - composer install -o
+
 
 script:
-  - vendor/bin/phpunit $PHPUNIT_ARGS
-  - if [ ${TRAVIS_PHP_VERSION:0:3} == "$CS" ] && [ "$GLPI_BRANCH" = "$AFTER_SUCCESS_BRANCH" ]; then vendor/bin/robo --no-interaction code:cs; fi
+  - vendor/bin/robo --no-interaction code:cs
+  - mysql -u root -e 'select version();'
+  - ./vendor/bin/atoum -bf tests/bootstrap.php -d tests/units/
+
+
+matrix:
+  exclude:
+    - php: 5.6
+      env: GLPIVER=master
+    - php: 5.6
+      env: GLPIVER=9.4/bugfixes
+  allow_failures:
+    - php: nightly
+    - env: GLPIVER=9.2/bugfixes
 
 cache:
   directories:
     - $HOME/.composer/cache
+
+#notifications:
+#  irc:
+#    channels:
+#      - "irc.freenode.org#channel"
+#    on_success: change
+#    on_failure: always
+#    use_notice: true
+#    skip_join: true

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This is project's console commands configuration for Robo task runner.
+ *
+ * @see http://robo.li/
+ */
+
+require_once 'vendor/autoload.php';
+
+class RoboFile extends Glpi\Tools\RoboFile
+{
+   protected $csignore = ['/vendor/','./vendor/'];
+   protected $csfiles = ['./'];
+   //Own plugin's robo stuff
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "require-dev": {
+              "squizlabs/php_codesniffer": "^3.3.2"
+    },
+    "config": {
+        "platform": {
+            "php": "5.6"
+        }
+    },
+    "require": {
+        "glpi-project/tools": "^0.1.5"
+    }
+}

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -400,8 +400,8 @@ JAVASCRIPT;
          $html.="<tr class='tab_bg_2'><td>".__("Duration Diff", "actiontime")."</td><td style='color:".$color."'>".HTML::timestampToString($diff)."</td></tr>";
          if ($total_time==0) {
             $diffpercent=0;
-         }else{
-            $diffpercent=100*($total_time-$actual_totaltime)/$total_time; 
+         } else {
+            $diffpercent=100*($total_time-$actual_totaltime)/$total_time;
          }
          $html.="<tr class='tab_bg_2'><td>".__("Duration Diff", "actiontime")." (%)</td><td style='color:".$color."'>".round($diffpercent, 2)."%</td></tr>";
 
@@ -471,7 +471,7 @@ JAVASCRIPT;
             $html.="<td style='color:".$color."'>".HTML::timestampToString($value['total']-$value['actual_total'])."</td>";
             if ($value['total']==0) {
                $html.="<td style='color:".$color."'>0%</td></tr>";
-            }else{
+            } else {
                $html.="<td style='color:".$color."'>".round(100*($value['total']-$value['actual_total'])/$value['total'])."%</td></tr>";
             }
          }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,33 @@
+<?php
+// fix empty CFG_GLPI on boostrap; see https://github.com/sebastianbergmann/phpunit/issues/325
+global $CFG_GLPI;
+
+//define plugin paths
+define("PLUGINACTUALTIME_DOC_DIR", __DIR__ . "/generated_test_data");
+
+define('GLPI_ROOT', dirname(dirname(dirname(__DIR__))));
+define("GLPI_CONFIG_DIR", GLPI_ROOT . "/tests");
+include GLPI_ROOT . "/inc/includes.php";
+include_once GLPI_ROOT . '/tests/GLPITestCase.php';
+include_once GLPI_ROOT . '/tests/DbTestCase.php';
+
+//install plugin
+$plugin = new \Plugin();
+$plugin->getFromDBbyDir('actualtime');
+
+//check from prerequisites as Plugin::install() does not!
+if (!plugin_actualtime_check_prerequisites()) {
+   echo "\nPrerequisites are not met!";
+   die(1);
+}
+
+if (!$plugin->isInstalled('actualtime')) {
+   echo "tem que instalar\n";
+   call_user_func([$plugin, 'install'], $plugin->getID());
+}
+echo "instalado\n";
+if (!$plugin->isActivated('actualtime')) {
+   echo "tem que ativar\n";
+   call_user_func([$plugin, 'activate'], $plugin->getID());
+}
+echo "ativado\n";

--- a/tests/units/PluginActualtimeTask.php
+++ b/tests/units/PluginActualtimeTask.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace tests\units;
+
+use atoum;
+
+class PluginActualtimeTask extends atoum {
+
+   public function testGetTypeName() {
+      $this
+         ->if($class = $this->testedClass->getClass())
+         ->then
+            ->string($class::getTypeName())
+               ->isNotEmpty();
+   }
+
+   /*
+    * Actually is not easy to test the class, as it depends on already created
+    * ticket with already created task to start timer. In future we should
+    * probably emulate those tests. Now, just testing some results methods
+    * should return if there is no tasks at all.
+    */
+
+   public function testCheckTech() {
+      $this
+         ->if($class = $this->testedClass->getClass())
+         ->then
+            ->boolean($class::checkTech(1))
+               ->isFalse();
+   }
+
+   public function testCheckTimerActive() {
+      $this
+         ->if($class = $this->testedClass->getClass())
+         ->then
+            ->boolean($class::checkTimerActive(1))
+               ->isFalse();
+   }
+
+   public function testTotalEndTime() {
+      $this
+         ->if($class = $this->testedClass->getClass())
+         ->then
+            ->integer($class::totalEndTime(1))
+               ->isIdenticalTo(0);
+   }
+}


### PR DESCRIPTION
I finally got it working. With this commit, the new commits and pull requests will be correctly analyzed by Travis CI for syntax correctness and class working.

It is an ongoing work. Now we test the PluginActualtimeTask class and its methods, with a direct test to four methods, just to know the class is working in any Glpi install. We do not emulate a ticket task creating with timer starting and stopping, that would be a perfect test, but we can at least test the methods are returning the expected result (for a no task created environment).

Plugin is tested against Glpi's 9.2/bugfixes, 9.3/bugfixes, 9.4/bugfixes and master branches, with PHP versions 5.6 (up to Glpi 9.3), 7, 7.1, 7.2 and nightly. The tests with PHP nightly versions are not mandatory. So is all builds with Glpi version 9.2 (some erratic error are thrown with Glpi 9.2 that we could not figure out the reason, randomly the methods' tests pass or fail if you repeat the tests).