### PR TITLE
Update compatibility for Travis CI issue #12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 env:
@@ -12,7 +13,6 @@ env:
   matrix:
     - GLPIVER=9.4/bugfixes
     - GLPIVER=9.3/bugfixes
-    - GLPIVER=9.2/bugfixes
     - GLPIVER=master
 
 before_script:
@@ -42,7 +42,6 @@ matrix:
       env: GLPIVER=9.4/bugfixes
   allow_failures:
     - php: nightly
-    - env: GLPIVER=9.2/bugfixes
 
 cache:
   directories:

--- a/setup.php
+++ b/setup.php
@@ -15,6 +15,7 @@ function plugin_version_actualtime() {
          'glpi'   => [
             'min' => PLUGIN_ACTUALTIME_MIN_GLPI,
             'max' => PLUGIN_ACTUALTIME_MAX_GLPI,
+            'dev' => true
          ]
       ]];
 }
@@ -28,10 +29,11 @@ function plugin_actualtime_check_prerequisites() {
    $matchMaxGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MAX_GLPI, '<=');
    if (!$matchMinGlpiReq || !$matchMaxGlpiReq) {
       echo vsprintf(
-         'This plugin requires GLPI >= %1$s and <= %2$s.',
+         'This plugin requires GLPI >= %1$s and <= %2$s (%3$s).',
          [
             PLUGIN_ACTUALTIME_MIN_GLPI,
             PLUGIN_ACTUALTIME_MAX_GLPI,
+            $version,
          ]
       );
       return false;

--- a/setup.php
+++ b/setup.php
@@ -37,7 +37,7 @@ function plugin_actualtime_check_prerequisites() {
          Plugin::messageIncompatible('core', PLUGIN_ACTUALTIME_MIN_GLPI, PLUGIN_ACTUALTIME_MAX_GLPI);
       } else {
          echo vsprintf(
-            'This plugin requires GLPI >= %1$s and <= %2$s.',
+            'This plugin requires GLPI >= %1$s and < %2$s.',
             [
                PLUGIN_ACTUALTIME_MIN_GLPI,
                PLUGIN_ACTUALTIME_MAX_GLPI,

--- a/setup.php
+++ b/setup.php
@@ -14,8 +14,8 @@ function plugin_version_actualtime() {
       'requirements'   => [
          'glpi'   => [
             'min' => PLUGIN_ACTUALTIME_MIN_GLPI,
-            'max' => PLUGIN_ACTUALTIME_MAX_GLPI,
-            'dev' => true
+            // Allow all version from PLUGIN_ACTUALTIME_MIN_GLPI
+            //'max' => PLUGIN_ACTUALTIME_MAX_GLPI,
          ]
       ]];
 }
@@ -25,17 +25,25 @@ function plugin_version_actualtime() {
  */
 function plugin_actualtime_check_prerequisites() {
    $version = preg_replace('/^((\d+\.?)+).*$/', '$1', GLPI_VERSION);
-   $matchMinGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MIN_GLPI, '>=');
-   $matchMaxGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MAX_GLPI, '<=');
+   // Devel version allowed
+   if ($version == '10.0.0') {
+      return true;
+   }
+   $matchMinGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MIN_GLPI, 'ge');
+   $matchMaxGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MAX_GLPI, 'lt');
    if (!$matchMinGlpiReq || !$matchMaxGlpiReq) {
-      echo vsprintf(
-         'This plugin requires GLPI >= %1$s and <= %2$s (%3$s).',
-         [
-            PLUGIN_ACTUALTIME_MIN_GLPI,
-            PLUGIN_ACTUALTIME_MAX_GLPI,
-            $version,
-         ]
-      );
+      if (method_exists('Plugin', 'messageIncompatible')) {
+         //since GLPI 9.2
+         Plugin::messageIncompatible('core', PLUGIN_ACTUALTIME_MIN_GLPI, PLUGIN_ACTUALTIME_MAX_GLPI);
+      } else {
+         echo vsprintf(
+            'This plugin requires GLPI >= %1$s and <= %2$s.',
+            [
+               PLUGIN_ACTUALTIME_MIN_GLPI,
+               PLUGIN_ACTUALTIME_MAX_GLPI,
+            ]
+         );
+      }
       return false;
    }
    return true;

--- a/setup.php
+++ b/setup.php
@@ -10,8 +10,7 @@ function plugin_version_actualtime() {
       'version'        => PLUGIN_ACTUALTIME_VERSION,
       'author'         => '<a href="https://tic.gal">TICgal</a>',
       'homepage'       => 'https://tic.gal',
-      'license'        => 'GPLv3+',
-      'minGlpiVersion' => "9.2",
+      'license'        => 'AGPLv3+',
       'requirements'   => [
          'glpi'   => [
             'min' => PLUGIN_ACTUALTIME_MIN_GLPI,
@@ -25,21 +24,18 @@ function plugin_version_actualtime() {
  */
 function plugin_actualtime_check_prerequisites() {
    $version = preg_replace('/^((\d+\.?)+).*$/', '$1', GLPI_VERSION);
-   if (version_compare($version, '9.2', '<')) {
-      $matchMinGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MIN_GLPI, '>=');
-      $matchMaxGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MAX_GLPI, '<');
-      if (!$matchMinGlpiReq || !$matchMaxGlpiReq) {
-         echo vsprintf(
-            'This plugin requires GLPI >= %1$s and < %2$s.',
-            [
-               PLUGIN_ACTUALTIME_MIN_GLPI,
-               PLUGIN_ACTUALTIME_MAX_GLPI,
-            ]
-         );
-         return false;
-      }
+   $matchMinGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MIN_GLPI, '>=');
+   $matchMaxGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MAX_GLPI, '<');
+   if (!$matchMinGlpiReq || !$matchMaxGlpiReq) {
+      echo vsprintf(
+         'This plugin requires GLPI >= %1$s and < %2$s.',
+         [
+            PLUGIN_ACTUALTIME_MIN_GLPI,
+            PLUGIN_ACTUALTIME_MAX_GLPI,
+         ]
+      );
+      return false;
    }
-
    return true;
 }
 

--- a/setup.php
+++ b/setup.php
@@ -25,10 +25,10 @@ function plugin_version_actualtime() {
 function plugin_actualtime_check_prerequisites() {
    $version = preg_replace('/^((\d+\.?)+).*$/', '$1', GLPI_VERSION);
    $matchMinGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MIN_GLPI, '>=');
-   $matchMaxGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MAX_GLPI, '<');
+   $matchMaxGlpiReq = version_compare($version, PLUGIN_ACTUALTIME_MAX_GLPI, '<=');
    if (!$matchMinGlpiReq || !$matchMaxGlpiReq) {
       echo vsprintf(
-         'This plugin requires GLPI >= %1$s and < %2$s.',
+         'This plugin requires GLPI >= %1$s and <= %2$s.',
          [
             PLUGIN_ACTUALTIME_MIN_GLPI,
             PLUGIN_ACTUALTIME_MAX_GLPI,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,12 +22,9 @@ if (!plugin_actualtime_check_prerequisites()) {
 }
 
 if (!$plugin->isInstalled('actualtime')) {
-   echo "tem que instalar\n";
    call_user_func([$plugin, 'install'], $plugin->getID());
 }
-echo "instalado\n";
+
 if (!$plugin->isActivated('actualtime')) {
-   echo "tem que ativar\n";
    call_user_func([$plugin, 'activate'], $plugin->getID());
 }
-echo "ativado\n";


### PR DESCRIPTION
Issue #12  

Updated system to enforce compatibility only from 9.3 and up, including devel 10.0.0 (dropped 9.2).

Updated Travis CI tests to include php 7.3 and exclude Glpi 9.2.