### PR TITLE
Auto update task form

### DIFF
--- a/ajax/timer.php
+++ b/ajax/timer.php
@@ -72,6 +72,7 @@ if (isset($_POST["action"])) {
                   'title' => __s('Information'),
                   'class' => 'info_msg',
                   'html' => PluginActualtimeTask::getSegment($task_id),
+                  'realclock' => HTML::timestampToString(PluginActualtimeTask::totalEndTime($task_id)),
                ];
             } else {
                $result=[

--- a/ajax/timer.php
+++ b/ajax/timer.php
@@ -71,6 +71,7 @@ if (isset($_POST["action"])) {
                   'mensage'=>__("Timer completed", 'actualtime'),
                   'title' => __s('Information'),
                   'class' => 'info_msg',
+                  'html' => PluginActualtimeTask::getSegment($task_id),
                ];
             } else {
                $result=[

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -55,6 +55,7 @@ class PluginActualtimeTask extends CommonDBTM{
                   echo $html;
 
                   $ajax_url=$CFG_GLPI['root_doc']."/plugins/actualtime/ajax/timer.php";
+                  $done=__('Done');
 
                   $script=<<<JAVASCRIPT
 						$(document).ready(function(){
@@ -137,7 +138,7 @@ class PluginActualtimeTask extends CommonDBTM{
 									success: function (result) {
 										if (val=='end' && result['class']=='info_msg') {
 											$("table:has(#actualtime{$rand}) select[name='state']").val(2).trigger('change');
-											$('#actualtime{$rand}').parentsUntil('.h_item','.h_content.TicketTask').find('span.state.state_1').toggleClass('state_1 state_2');
+											$('#actualtime{$rand}').parentsUntil('.h_item','.h_content.TicketTask').find('span.state.state_1').toggleClass('state_1 state_2').attr('title','$done');
 											$('#actualtime{$rand}').remove();
 											endCount(result['realclock']);
 											// Refresh table of partial time periods for this task

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -49,7 +49,9 @@ class PluginActualtimeTask extends CommonDBTM{
                   $html.="<td class='center'>".__("Start date")."</td><td class='center'>".__("Partial actual duration", 'actualtime')."</td>";
                   $html.="<td>".__('Actual Duration', 'actualtime')." </td><td id='real_clock$rand'>".HTML::timestampToString($time)."</td>";
                   $html.="</tr>";
+                  $html.="<tr id='actualtimeseg{$rand}'>";
                   $html.=self::getSegment($item->getID());
+                  $html.="</tr>";
                   echo $html;
 
                   $ajax_url=$CFG_GLPI['root_doc']."/plugins/actualtime/ajax/timer.php";
@@ -135,6 +137,8 @@ class PluginActualtimeTask extends CommonDBTM{
 											$("table:has(#actualtime{$rand}) select[name='state']").val(2).trigger('change');
 											$('#actualtime{$rand}').remove();
 											endCount();
+											// Refresh table of partial time periods for this task
+											$('#actualtimeseg{$rand}').html(result['html']);
 										}else{
 											if (val=='start' && result['class']=='info_msg') {
 												$('#actualtime{$rand}').attr('action','end');
@@ -200,7 +204,9 @@ JAVASCRIPT;
                   $html.="<td class='center'>".__("Start date")."</td><td class='center'>".__("Partial actual duration", 'actualtime')."</td>";
                   $html.="<td>".__('Actual Duration', 'actualtime')." </td><td id='real_clock$rand'>".HTML::timestampToString($time)."</td>";
                   $html.="</div></td></tr>";
+                  $html.="<tr id='actualtimeseg{$rand}'>";
                   $html.=self::getSegment($item->getID());
+                  $html.="</tr>";
                   echo $html;
                }
             }
@@ -512,11 +518,11 @@ JAVASCRIPT;
             ],
          ]
       ];
-      $html="<tr><td colspan='2'><table class='tab_cadre_fixe'>";
+      $html="<td colspan='2'><table class='tab_cadre_fixe'>";
       foreach ($DB->request($query) as $id => $row) {
          $html.="<tr class='tab_bg_2'><td>".$row['actual_begin']."</td><td>".HTML::timestampToString($row['actual_actiontime'])."</td></tr>";
       }
-      $html.="</table></td></tr>";
+      $html.="</table></td>";
       return $html;
    }
 

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -117,8 +117,10 @@ class PluginActualtimeTask extends CommonDBTM{
 								});
 							}
 
-							function endCount(){
+							function endCount(realclk){
 								clearInterval(x);
+								// Correct real time clock with the actual data in database
+								$('#real_clock{$rand}').html(realclk);
 								$('#real_clock{$rand}').css('color','black');
 							}
 
@@ -136,7 +138,7 @@ class PluginActualtimeTask extends CommonDBTM{
 										if (val=='end' && result['class']=='info_msg') {
 											$("table:has(#actualtime{$rand}) select[name='state']").val(2).trigger('change');
 											$('#actualtime{$rand}').remove();
-											endCount();
+											endCount(result['realclock']);
 											// Refresh table of partial time periods for this task
 											$('#actualtimeseg{$rand}').html(result['html']);
 										}else{

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -137,6 +137,7 @@ class PluginActualtimeTask extends CommonDBTM{
 									success: function (result) {
 										if (val=='end' && result['class']=='info_msg') {
 											$("table:has(#actualtime{$rand}) select[name='state']").val(2).trigger('change');
+											$('#actualtime{$rand}').parentsUntil('.h_item','.h_content.TicketTask').find('span.state.state_1').toggleClass('state_1 state_2');
 											$('#actualtime{$rand}').remove();
 											endCount(result['realclock']);
 											// Refresh table of partial time periods for this task


### PR DESCRIPTION
Solve issue #20 , with some minor changes:
- when stopping the timer, change also the task checkbox in tasks list to checked (task done). Currently, the state is only changed on the database and on the task form, and, if you close the form, this update is not reflected on the list (check box unchecked as the task was in To Do state.
- when stopping the timer, automatically update the list of periods timed (history) of timers (bottom of task form). Currently, the list of partial periods timed is not updated, so the only way to see this just ended period is closing and reopening the form.
- when stopping the timer, adjust Actual Duration time in task form to reflect the time recorded in the database. In some very few times, the total time updated by javascript on task form and the real total time in the database differ for 1 second and is only corrected if the form is closed and reopened.