### PR TITLE
Active timer pop-up in hook add-javascript, instead of post_show_item

### DIFF
--- a/ajax/timer.php
+++ b/ajax/timer.php
@@ -95,4 +95,25 @@ if (isset($_POST["action"])) {
          echo abs(PluginActualtimeTask::totalEndTime($task_id));
          break;
    }
+
+} else {
+
+   // GET method. Looking for current user active timer
+   if ($ticket_id = PluginActualtimeTask::getTicket(Session::getLoginUserID())) {
+      global $CFG_GLPI;
+      $rand = mt_rand();
+
+      $task_id = PluginActualtimeTask::getTask(Session::getLoginUserID());
+      $time = abs(PluginActualtimeTask::totalEndTime($task_id));
+      $result = [
+         'time' => $time,
+         'rand' => $rand,
+         'title' => __('Warning'),
+         'div' => "<div id='timer$rand'>".__("Timer started on", 'actualtime')." <a href='".$CFG_GLPI['root_doc']."/front/ticket.form.php?id=".$ticket_id."'>".__("Ticket")." ".$ticket_id."</a> -> <span>".HTML::timestampToString($time)."</span></div>",
+      ];
+   } else {
+      $result = ['time' => 0];
+   }
+   echo json_encode($result);
+
 }

--- a/js/actualtime.js
+++ b/js/actualtime.js
@@ -1,0 +1,75 @@
+$(document).ready(function(){
+   jQuery.ajax({
+      type: "GET",
+      url: '../plugins/actualtime/ajax/timer.php',
+      dataType: 'json',
+      success: function (result) {
+         if (result['time']) {
+            if ($("#timer" + result['rand']).length) {
+               $("#timer" + result['rand']).remove();
+            }
+            $("body").append(result['div']);
+            var time = result['time'];
+            x = setInterval(function() {
+               time += 1;
+               var distance = time;
+               var seconds = 0;
+               var minutes = 0;
+               var hours = 0;
+               var days = 0;
+               seconds = distance % 60;
+               distance -= seconds;
+               var text = seconds + " s";
+               if (distance > 0) {
+                  minutes = (distance % 3600) / 60;
+                  distance -= minutes * 60;
+                  text = minutes + " min " + text;
+                  if (distance > 0) {
+                     hours = (distance % 86400) / 3600;
+                     distance -= hours * 3600;
+                     text = hours + " h " + text;
+                     if (distance > 0) {
+                        days = distance / 86400;
+                        text = days + " d " + text;
+                     }
+                  }
+               }
+               $("#timer" + result['rand'] + " span").text(text);
+            }, 1000);
+            $("#timer" + result['rand']).attr('title', result['title']);
+            $(function() {
+               var _of = window;
+               var _at = 'right-20 bottom-20';
+               // calculate relative dialog position
+               $('.message_result').each(function() {
+                  var _this = $(this);
+                  if (_this.attr('aria-describedby') != 'message_result') {
+                     _of = _this;
+                     _at = 'right top-' + (10 + _this.outerHeight());
+                  }
+               });
+
+               $("#timer" + result['rand']).dialog({
+                  dialogClass: 'message_after_redirect warn_msg',
+                  minHeight: 40,
+                  minWidth: 200,
+                  position: {
+                     my: 'right bottom',
+                     at: _at,
+                     of: _of,
+                     collision: 'none'
+                  },
+                  autoOpen: false,
+                  show: {
+                     effect: 'slide',
+                     direction: 'down',
+                     'duration': 800
+                  }
+               })
+               .dialog('open');
+            });
+
+         }
+      }
+   });
+});

--- a/setup.php
+++ b/setup.php
@@ -64,6 +64,6 @@ function plugin_init_actualtime() {
    $PLUGIN_HOOKS['post_item_form']['actualtime'] = ['PluginActualtimeTask', 'postForm'];
    $PLUGIN_HOOKS['show_item_stats']['actualtime'] = ['Ticket'=> 'plugin_activetime_item_stats'];
    $PLUGIN_HOOKS['pre_item_update']['actualtime'] = ['TicketTask'=>'plugin_activetime_item_update'];
-   $PLUGIN_HOOKS['post_show_item']['actualtime'] = ['PluginActualtimeTask', 'postShowItem'];
+   $PLUGIN_HOOKS['add_javascript']['actualtime'] = "js/actualtime.js";
 
 }


### PR DESCRIPTION
As discussed on issue #24 , the post_show_item hook (and function) was removed and added add_javascript hook, so in every page once, and only once, a script is run, gets timer popup message via ajax, if current users's timer is active and show the dialog (and update timer every second).

The function is basically the same, just the insert point was changed. Now the timer popup appears **every** page, and appears only once, instead of many popups for each shown item.

(Travis CI tests only pass for Glpi 9.3, as it seems something has changed on their 'master' branch. Will look into that soon)