### PR TITLE
Multiple popup bug #24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ before_script:
   - composer self-update
   - composer require --dev atoum/atoum
   - git clone --depth=1 https://github.com/glpi-project/glpi -b $GLPIVER ../glpi && cd ../glpi
-  - composer install --no-dev
+  - composer install --optimize-autoloader --no-dev
+  - sed -e '/"php":/d' -i composer.json
+  - rm -f composer.lock
   - mysql -u root -e 'create database glpitest;'
   # Both 9.3 and 9.4:
   - if [[ -f "scripts/cliinstall.php" ]]; then php scripts/cliinstall.php --db=glpitest --user=root --tests; else bin/console glpi:database:install --config-dir=./tests --no-interaction --db-name=glpitest --db-user=root; fi
@@ -31,7 +33,7 @@ before_script:
 script:
   - vendor/bin/robo --no-interaction code:cs
   - mysql -u root -e 'select version();'
-  - ./vendor/bin/atoum -bf tests/bootstrap.php -d tests/units/
+  - ./vendor/bin/atoum --debug -bf tests/bootstrap.php -d tests/units/
 
 
 # Permit failure on Glpi 9.4 until fix test environment
@@ -43,8 +45,6 @@ matrix:
       env: GLPIVER=9.4/bugfixes
   allow_failures:
     - php: nightly
-    - env: GLPIVER=master
-    - env: GLPIVER=9.4/bugfixes
 
 cache:
   directories:

--- a/ajax/timer.php
+++ b/ajax/timer.php
@@ -145,6 +145,7 @@ if (isset($_POST["action"])) {
 
 } elseif (isset($_GET["footer"])) {
 
+   // For timer popup windows (called by atualtime.js)
    global $CFG_GLPI;
    // Base function for all general stuff in javascript
    // Translations
@@ -173,7 +174,7 @@ if (isset($_POST["action"])) {
       $result['task_id'] = $task_id;
       $result['ticket_id'] = PluginActualtimetask::getTicket(Session::getLoginUserID());
       $result['time'] = abs(PluginActualtimeTask::totalEndTime($task_id));
-      $result['div'] = "<div id='timer{$result['rand']}'>" . __("Timer started on", 'actualtime') . " <a onclick='showtaskform(event)' href='{$CFG_GLPI['root_doc']}/front/ticket.form.php?id={$result['ticket_id']}'>" . __("Ticket") . " {$result['ticket_id']}</a> -> <span></span></div>";
+      $result['div'] = "<div id='actualtime_timer{$result['rand']}'>" . __("Timer started on", 'actualtime') . " <a onclick='showtaskform(event)' href='{$CFG_GLPI['root_doc']}/front/ticket.form.php?id={$result['ticket_id']}'>" . __("Ticket") . " {$result['ticket_id']}</a> -> <span></span></div>";
    }
    echo json_encode($result);
 

--- a/ajax/timer.php
+++ b/ajax/timer.php
@@ -44,9 +44,11 @@ if (isset($_POST["action"])) {
                   ]
                );
                $result=[
-                  'mensage' => __("Timer started", 'actualtime'),
-                  'title'   => __('Information'),
-                  'class'   => 'info_msg',
+                  'mensage'   => __("Timer started", 'actualtime'),
+                  'title'     => __('Information'),
+                  'class'     => 'info_msg',
+                  'ticket_id' => PluginActualtimetask::getTicket(Session::getLoginUserID()),
+                  'time'      => abs(PluginActualtimeTask::totalEndTime($task_id)),
                ];
 
             }
@@ -89,8 +91,8 @@ if (isset($_POST["action"])) {
                   'mensage' => __("Timer completed", 'actualtime'),
                   'title'   => __('Information'),
                   'class'   => 'info_msg',
-                  'html' => PluginActualtimeTask::getSegment($task_id),
-                  'time' => abs(PluginActualtimeTask::totalEndTime($task_id)),
+                  'segment' => PluginActualtimeTask::getSegment($task_id),
+                  'time'    => abs(PluginActualtimeTask::totalEndTime($task_id)),
                ];
 
             } else {
@@ -126,11 +128,11 @@ if (isset($_POST["action"])) {
                   ]
                );
                $result=[
-                  'mensage'=>__("Timer completed", 'actualtime'),
-                  'title' => __('Information'),
-                  'class' => 'info_msg',
-                  'html' => PluginActualtimeTask::getSegment($task_id),
-                  'time' => abs(PluginActualtimeTask::totalEndTime($task_id)),
+                  'mensage' =>__("Timer completed", 'actualtime'),
+                  'title'   => __('Information'),
+                  'class'   => 'info_msg',
+                  'segment' => PluginActualtimeTask::getSegment($task_id),
+                  'time'    => abs(PluginActualtimeTask::totalEndTime($task_id)),
                ];
 
             }
@@ -167,16 +169,19 @@ if (isset($_POST["action"])) {
    $result['symb_s'] = __("%ds", "actualtime");
    $result['symb_second'] = _n("%d second", "%d seconds", 1);
    $result['symb_seconds'] = _n("%d second", "%d seconds", 2);
+   $result['text_warning'] = __('Warning');
+   $result['text_pause'] = __('Pause', 'actualtime');
+   $result['text_restart'] = __('Restart', 'actualtime');
+   $result['text_done'] = __('Done');
    // Current user active task. Data to timer popup
    $config = new PluginActualtimeConfig;
    if ($config->showTimerPopup()) {
       $task_id = PluginActualtimeTask::getTask(Session::getLoginUserID());
       if ($task_id) {
-         $result['warning'] = __('Warning');
          $result['task_id'] = $task_id;
          $result['ticket_id'] = PluginActualtimetask::getTicket(Session::getLoginUserID());
          $result['time'] = abs(PluginActualtimeTask::totalEndTime($task_id));
-         $result['div'] = "<div id='actualtime_timer{$result['rand']}'>" . __("Timer started on", 'actualtime') . " <a onclick='showtaskform(event)' href='{$CFG_GLPI['root_doc']}/front/ticket.form.php?id={$result['ticket_id']}'>" . __("Ticket") . " {$result['ticket_id']}</a> -> <span></span></div>";
+         $result['popup_div'] = "<div id='actualtime_popup'>" . __("Timer started on", 'actualtime') . " <a onclick='actualtime_showTaskForm(event)' href='{$CFG_GLPI['root_doc']}/front/ticket.form.php?id=%t'>" . __("Ticket") . " %t</a> -> <span></span></div>";
       }
    }
    echo json_encode($result);

--- a/ajax/timer.php
+++ b/ajax/timer.php
@@ -176,12 +176,14 @@ if (isset($_POST["action"])) {
    // Current user active task. Data to timer popup
    $config = new PluginActualtimeConfig;
    if ($config->showTimerPopup()) {
+      // popup_div exists only if settings allow display pop-up timer
+      $result['popup_div'] = "<div id='actualtime_popup'>" . __("Timer started on", 'actualtime') . " <a onclick='actualtime_showTaskForm(event)' href='{$CFG_GLPI['root_doc']}/front/ticket.form.php?id=%t'>" . __("Ticket") . " %t</a> -> <span></span></div>";
       $task_id = PluginActualtimeTask::getTask(Session::getLoginUserID());
       if ($task_id) {
+         // Only if timer is active
          $result['task_id'] = $task_id;
          $result['ticket_id'] = PluginActualtimetask::getTicket(Session::getLoginUserID());
          $result['time'] = abs(PluginActualtimeTask::totalEndTime($task_id));
-         $result['popup_div'] = "<div id='actualtime_popup'>" . __("Timer started on", 'actualtime') . " <a onclick='actualtime_showTaskForm(event)' href='{$CFG_GLPI['root_doc']}/front/ticket.form.php?id=%t'>" . __("Ticket") . " %t</a> -> <span></span></div>";
       }
    }
    echo json_encode($result);

--- a/ajax/timer.php
+++ b/ajax/timer.php
@@ -7,6 +7,7 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 if (isset($_POST["action"])) {
+
    $task_id=$_POST["task_id"];
    switch ($_POST["action"]) {
       case 'start':
@@ -141,7 +142,44 @@ if (isset($_POST["action"])) {
          echo abs(PluginActualtimeTask::totalEndTime($task_id));
          break;
    }
+
+} elseif (isset($_GET["footer"])) {
+
+   global $CFG_GLPI;
+   // Base function for all general stuff in javascript
+   // Translations
+   $result = [];
+   $result['rand'] = mt_rand();
+   $result['warning'] = __('Warning');
+   //TRANS: d is a symbol for days in a time (displays: 3d)
+   $result['symb_d'] = __("%dd", "actualtime");;
+   $result['symb_day'] = _n("%d day", "%d days", 1); 
+   $result['symb_days'] = _n("%d day", "%d days", 2); 
+   //TRANS: h is a symbol for hours in a time (displays: 3h)
+   $result['symb_h'] = __("%dh", "actualtime");;
+   $result['symb_hour'] = _n("%d hour", "%d hours", 1); 
+   $result['symb_hours'] = _n("%d hour", "%d hours", 2); 
+   //TRANS: min is a symbol for minutes in a time (displays: 3min)
+   $result['symb_min'] = __("%dmin", "actualtime");;
+   $result['symb_minute'] = _n("%d minute", "%d minutes", 1); 
+   $result['symb_minutes'] = _n("%d minute", "%d minutes", 2); 
+   //TRANS: s is a symbol for seconds in a time (displays: 3s)
+   $result['symb_s'] = __("%ds", "actualtime");;
+   $result['symb_second'] = _n("%d second", "%d seconds", 1); 
+   $result['symb_seconds'] = _n("%d second", "%d seconds", 2); 
+   // Current user active task
+   $task_id = PluginActualtimeTask::getTask(Session::getLoginUserID());
+   if ($task_id) {
+      $result['task_id'] = $task_id;
+      $result['ticket_id'] = PluginActualtimetask::getTicket(Session::getLoginUserID());
+      $result['time'] = abs(PluginActualtimeTask::totalEndTime($task_id));
+      $result['div'] = "<div id='timer{$result['rand']}'>" . __("Timer started on", 'actualtime') . " <a onclick='showtaskform(event)' href='{$CFG_GLPI['root_doc']}/front/ticket.form.php?id={$result['ticket_id']}'>" . __("Ticket") . " {$result['ticket_id']}</a> -> <span></span></div>";
+   }
+   echo json_encode($result);
+
 } else {
+
+   // For modal windows
    $parts = parse_url($_SERVER['REQUEST_URI']);
    parse_str($parts['query'], $query);
    if (isset($query['showform'])) {
@@ -156,4 +194,5 @@ if (isset($_POST["action"])) {
       $item = getItemForItemtype("TicketTask");
       $item->showForm($task_id, $options);
    }
+
 }

--- a/ajax/timer.php
+++ b/ajax/timer.php
@@ -90,7 +90,7 @@ if (isset($_POST["action"])) {
                   'title'   => __('Information'),
                   'class'   => 'info_msg',
                   'html' => PluginActualtimeTask::getSegment($task_id),
-                  'realclock' => HTML::timestampToString(PluginActualtimeTask::totalEndTime($task_id)),
+                  'time' => abs(PluginActualtimeTask::totalEndTime($task_id)),
                ];
 
             } else {
@@ -130,7 +130,7 @@ if (isset($_POST["action"])) {
                   'title' => __('Information'),
                   'class' => 'info_msg',
                   'html' => PluginActualtimeTask::getSegment($task_id),
-                  'realclock' => HTML::timestampToString(PluginActualtimeTask::totalEndTime($task_id)),
+                  'time' => abs(PluginActualtimeTask::totalEndTime($task_id)),
                ];
 
             }
@@ -151,7 +151,6 @@ if (isset($_POST["action"])) {
    // Translations
    $result = [];
    $result['rand'] = mt_rand();
-   $result['warning'] = __('Warning');
    //TRANS: d is a symbol for days in a time (displays: 3d)
    $result['symb_d'] = __("%dd", "actualtime");;
    $result['symb_day'] = _n("%d day", "%d days", 1); 
@@ -168,13 +167,17 @@ if (isset($_POST["action"])) {
    $result['symb_s'] = __("%ds", "actualtime");;
    $result['symb_second'] = _n("%d second", "%d seconds", 1); 
    $result['symb_seconds'] = _n("%d second", "%d seconds", 2); 
-   // Current user active task
-   $task_id = PluginActualtimeTask::getTask(Session::getLoginUserID());
-   if ($task_id) {
-      $result['task_id'] = $task_id;
-      $result['ticket_id'] = PluginActualtimetask::getTicket(Session::getLoginUserID());
-      $result['time'] = abs(PluginActualtimeTask::totalEndTime($task_id));
-      $result['div'] = "<div id='actualtime_timer{$result['rand']}'>" . __("Timer started on", 'actualtime') . " <a onclick='showtaskform(event)' href='{$CFG_GLPI['root_doc']}/front/ticket.form.php?id={$result['ticket_id']}'>" . __("Ticket") . " {$result['ticket_id']}</a> -> <span></span></div>";
+   // Current user active task. Data to timer popup
+   $config = new PluginActualtimeConfig;
+   if ($config->showTimerPopup()) {
+      $task_id = PluginActualtimeTask::getTask(Session::getLoginUserID());
+      if ($task_id) {
+         $result['warning'] = __('Warning');
+         $result['task_id'] = $task_id;
+         $result['ticket_id'] = PluginActualtimetask::getTicket(Session::getLoginUserID());
+         $result['time'] = abs(PluginActualtimeTask::totalEndTime($task_id));
+         $result['div'] = "<div id='actualtime_timer{$result['rand']}'>" . __("Timer started on", 'actualtime') . " <a onclick='showtaskform(event)' href='{$CFG_GLPI['root_doc']}/front/ticket.form.php?id={$result['ticket_id']}'>" . __("Ticket") . " {$result['ticket_id']}</a> -> <span></span></div>";
+      }
    }
    echo json_encode($result);
 

--- a/ajax/timer.php
+++ b/ajax/timer.php
@@ -143,7 +143,7 @@ if (isset($_POST["action"])) {
          break;
    }
 
-} elseif (isset($_GET["footer"])) {
+} else if (isset($_GET["footer"])) {
 
    // For timer popup windows (called by atualtime.js)
    global $CFG_GLPI;
@@ -152,21 +152,21 @@ if (isset($_POST["action"])) {
    $result = [];
    $result['rand'] = mt_rand();
    //TRANS: d is a symbol for days in a time (displays: 3d)
-   $result['symb_d'] = __("%dd", "actualtime");;
-   $result['symb_day'] = _n("%d day", "%d days", 1); 
-   $result['symb_days'] = _n("%d day", "%d days", 2); 
+   $result['symb_d'] = __("%dd", "actualtime");
+   $result['symb_day'] = _n("%d day", "%d days", 1);
+   $result['symb_days'] = _n("%d day", "%d days", 2);
    //TRANS: h is a symbol for hours in a time (displays: 3h)
-   $result['symb_h'] = __("%dh", "actualtime");;
-   $result['symb_hour'] = _n("%d hour", "%d hours", 1); 
-   $result['symb_hours'] = _n("%d hour", "%d hours", 2); 
+   $result['symb_h'] = __("%dh", "actualtime");
+   $result['symb_hour'] = _n("%d hour", "%d hours", 1);
+   $result['symb_hours'] = _n("%d hour", "%d hours", 2);
    //TRANS: min is a symbol for minutes in a time (displays: 3min)
-   $result['symb_min'] = __("%dmin", "actualtime");;
-   $result['symb_minute'] = _n("%d minute", "%d minutes", 1); 
-   $result['symb_minutes'] = _n("%d minute", "%d minutes", 2); 
+   $result['symb_min'] = __("%dmin", "actualtime");
+   $result['symb_minute'] = _n("%d minute", "%d minutes", 1);
+   $result['symb_minutes'] = _n("%d minute", "%d minutes", 2);
    //TRANS: s is a symbol for seconds in a time (displays: 3s)
-   $result['symb_s'] = __("%ds", "actualtime");;
-   $result['symb_second'] = _n("%d second", "%d seconds", 1); 
-   $result['symb_seconds'] = _n("%d second", "%d seconds", 2); 
+   $result['symb_s'] = __("%ds", "actualtime");
+   $result['symb_second'] = _n("%d second", "%d seconds", 1);
+   $result['symb_seconds'] = _n("%d second", "%d seconds", 2);
    // Current user active task. Data to timer popup
    $config = new PluginActualtimeConfig;
    if ($config->showTimerPopup()) {

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -117,13 +117,6 @@ class PluginActualtimeConfig extends CommonDBTM {
       return true;
    }
 
-   static function postItemForm(array $params) {
-      echo "<tr><td>postItemForm AQUI</td></tr>";
-   }
-   static function postShowItem(array $params) {
-      echo "<tr><td>postShowItem AQUI</td></tr>";
-   }
-
    /**
     * Plugin is enabled in plugin settings?
     *

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -66,8 +66,8 @@ class PluginActualtimeConfig extends CommonDBTM {
 
       echo "<input type='hidden' name='id' value='1'>";
 
-      echo "<tr class='tab_bg_1'>
-            <td>" . __("Enable timer on tasks", "actualtime") . "</td><td>";
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>" . __("Enable timer on tasks", "actualtime") . "</td><td>";
       Dropdown::showYesNo('enable', $this->isEnabled(), -1,
                           ['on_change' => 'show_hide_options(this.value);']);
       echo "</td>";
@@ -82,8 +82,10 @@ class PluginActualtimeConfig extends CommonDBTM {
       $style = ($this->isEnabled()) ? "" : "style='display: none '";
 
       // Include lines with other settings
-      echo "<tr class='tab_bg_1' name='optional$rand' $style>
-         <td>    ";
+
+      echo "<tr class='tab_bg_1' name='optional$rand' $style>";
+      echo "<td>" . __("Display pop-up window with current running timer", "actualtime") . "</td><td>";
+      Dropdown::showYesNo('showtimerpopup', $this->showTimerPopup(), -1);
       echo "</td>";
       echo "</tr>";
 
@@ -123,10 +125,21 @@ class PluginActualtimeConfig extends CommonDBTM {
    }
 
    /**
-    * @return mixed
+    * Plugin is enabled in plugin settings?
+    *
+    * @return boolean
     */
    function isEnabled() {
       return ($this->fields['enable'] ? true : false);
+   }
+
+   /**
+    * Timer pop-up display on every page enabled in plugin settings?
+    *
+    * @return boolean
+    */
+   function showTimerPopup() {
+      return ($this->fields['showtimerpopup'] ? true : false);
    }
 
    static function install(Migration $migration) {
@@ -157,20 +170,16 @@ class PluginActualtimeConfig extends CommonDBTM {
             );
          }
 
-         // New settings (fields)
-         //$migration->addField(
-         //   $table,
-         //   'newsettingfieldname',
-         //   'newsettingfieldtype',
-         //   'newsettingfieldoptions',
-         //);
-         //$DB->update(
-         //   $table, [
-         //      'newsettingfieldname' => 'defaultvalue'
-         //   ], [
-         //      'id' => 1
-         //   ]
-         //);
+         $migration->addField(
+            $table,
+            'showtimerpopup',
+            'boolean',
+            [
+               'update' => 1,
+               'value'  => 1,
+               'after' => 'enable'
+            ]
+         );
 
       }
 

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -615,6 +615,15 @@ JAVASCRIPT;
       }
    }
 
+   static function postShowTab($params) {
+      $script=<<<JAVASCRIPT
+$(document).ready(function(){
+   showTimerPopup();
+});
+JAVASCRIPT;
+      echo Html::scriptBlock($script);
+   }
+      
    static function install(Migration $migration) {
       global $DB;
 

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -86,6 +86,12 @@ class PluginActualtimeTask extends CommonDBTM{
 
                   $ajax_url=$CFG_GLPI['root_doc']."/plugins/actualtime/ajax/timer.php";
                   $done=__('Done');
+                  $config = new PluginActualtimeConfig;
+                  if ($config->showTimerPopup()) {
+                     $showtimerpopup =  'true';
+                  } else {
+                     $showtimerpopup = 'false';
+                  }
 
                   $script=<<<JAVASCRIPT
 function showtaskform(e) {
@@ -123,41 +129,19 @@ $(document).ready(function() {
          data:     {action: 'count', task_id: id},
          success:  function (result) {
             var time=result;
+            $('#real_clock{$rand}').text(timeToText(time, 3));
             x=setInterval(function() {
                time += 1;
-               var text;
-               var distance = time;
-               var seconds = 0;
-               var minutes = 0;
-               var hours = 0;
-               var days = 0;
-               seconds = distance % 60;
-               distance -= seconds;
-               text = seconds + " s";
-               if (distance > 0) {
-                  minutes = (distance % 3600) / 60;
-                  distance -= minutes * 60;
-                  text = minutes + " m " + seconds + " s";
-                  if (distance > 0) {
-                     hours = (distance % 86400) / 3600;
-                     distance -= hours * 3600;
-                     text = hours + " h " + minutes + " m " + seconds + " s";
-                     if (distance > 0) {
-                        days = distance / 86400;
-                        text = days + " d " + hours + " h " + minutes + " m " + seconds + " s";
-                     }
-                  }
-               }
-               $('#real_clock{$rand}').text(text);
+               $('#real_clock{$rand}').text(timeToText(time, 3));
             },1000);
          },
       });
    }
 
-   function endCount(realclk){
+   function endCount(time){
       clearInterval(x);
       // Correct real time clock with the actual data in database
-      $('#real_clock{$rand}').html(realclk);
+      $('#real_clock{$rand}').text(timeToText(time, 3));
       $('#real_clock{$rand}').css('color','black');
    }
 
@@ -188,7 +172,7 @@ $(document).ready(function() {
                   } else {
                      $('#actualtime1{$rand}').attr('value','$text_restart').attr('action','start').css('background-color','green').prop('disabled',false);
                   }
-                  endCount(result['realclock']);
+                  endCount(result['time']);
                   $('#actualtimeseg{$rand}').html(result['html']);
                   // remove timer popup
                   $('[id^="actualtime_timer"]').remove();
@@ -196,9 +180,11 @@ $(document).ready(function() {
                   $('#actualtime1{$rand}').attr('value','$text_pause').attr('action','pause').css('background-color','orange').prop('disabled',false);
                   $('#actualtime2{$rand}').attr('action','end').css('background-color','red').prop('disabled',false);
                   startCount(id);
-                  // show timer popup
-                  showTimerPopup();
-                  return;
+                  if ({$showtimerpopup}) {
+                     // show timer popup
+                     showTimerPopup();
+                     return;
+                  }
                }
             }
             $('#message_result').html(result['mensage']);

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -392,23 +392,12 @@ JAVASCRIPT;
    }
 
    static function getTicket($user_id) {
-      global $DB;
-
-      $query=[
-         'FROM'=>self::getTable(),
-         'WHERE'=>[
-            [
-               'NOT' => ['actual_begin' => null],
-            ],
-            'actual_end'=>null,
-            'users_id'=>$user_id,
-         ]
-      ];
-      $req=$DB->request($query);
-      $row=$req->next();
-      $task=new TicketTask();
-      $task->getFromDB($row['tasks_id']);
-      return $task->fields['tickets_id'];
+      if ($task_id=self::getTask($user_id)) {
+         $task=new TicketTask();
+         $task->getFromDB($task_id);
+         return $task->fields['tickets_id'];
+      }
+      return false;
    }
 
    static function getTask($user_id) {
@@ -618,116 +607,6 @@ JAVASCRIPT;
                ]
             );
          }
-      }
-   }
-
-   static public function postShowItem($params) {
-      global $DB,$CFG_GLPI;
-
-      $query=[
-         'FROM'=>self::getTable(),
-         'WHERE'=>[
-            [
-               'NOT' => ['actual_begin' => null],
-            ],
-            'actual_end'=>null,
-            'users_id'=>Session::getLoginUserID(),
-         ]
-      ];
-      $req=$DB->request($query);
-      if ($row=$req->next()) {
-
-         $rand = mt_rand();
-         $warning=__s('Warning');
-         $seconds=self::totalEndTime($row['tasks_id']);
-         $ticket_id=self::getTicket(Session::getLoginUserID());
-         $ajax_url=$CFG_GLPI['root_doc']."/plugins/actualtime/ajax/timer.php";
-
-         $div="<div id='timer$rand'>".__("Timer started on", 'actualtime')." <a onclick='showtaskform(event)' href='".$CFG_GLPI['root_doc']."/front/ticket.form.php?id=".$ticket_id."'>".__("Ticket")." ".$ticket_id."</a> -> <span>".HTML::timestampToString($seconds)."</span></div>";
-         $script=<<<JAVASCRIPT
-function showtaskform(e){
-   e.preventDefault();
-   $('<div>')
-      .dialog({
-         modal:  true,
-         width:  'auto',
-         height: 'auto',
-      })
-      .load('{$ajax_url}?showform=true', function() {
-         $(this).dialog('option', 'position', ['center', 'center'] );
-      });
-}
-$(document).ready(function() {
-   if ($("#timer{$rand}").length) {
-      $("#timer{$rand}").remove();
-   }
-   $("body").append("{$div}");
-   var time = {$seconds};
-   timer = setInterval(function() {
-      time += 1;
-
-      var text;
-      var distance = time;
-      var seconds = 0;
-      var minutes = 0;
-      var hours = 0;
-      var days = 0;
-      seconds = distance % 60;
-      distance -= seconds;
-      text = seconds + " s";
-
-      if (distance > 0) {
-         minutes = (distance % 3600) / 60;
-         distance -= minutes * 60;
-         text = minutes + " m " + seconds + " s";
-         if (distance > 0) {
-            hours = (distance % 86400) / 3600;
-            distance -= hours * 3600;
-            text = hours + " h " + minutes + " m " + seconds + " s";
-            if (distance > 0) {
-               days = distance / 86400;
-               text = days + " d " + hours + " h " + minutes + " m " + seconds + " s";
-            }
-         }
-      }
-
-      $('#timer{$rand} span').text(text);
-   },1000);
-   $('#timer{$rand}').attr('title', '{$warning}');
-   $(function() {
-      var _of = window;
-      var _at = 'right-20 bottom-20';
-      //calculate relative dialog position
-      $('.message_result').each(function() {
-         var _this = $(this);
-         if (_this.attr('aria-describedby') != 'message_result') {
-            _of = _this;
-            _at = 'right top-' + (10 + _this.outerHeight());
-         }
-      });
-
-      $('#timer{$rand}').dialog({
-         dialogClass: 'message_after_redirect warn_msg',
-         minHeight:   40,
-         minWidth:    200,
-         position:    {
-            my:        'right bottom',
-            at:        _at,
-            of:        _of,
-            collision: 'none'
-         },
-         autoOpen:    false,
-         show:        {
-            effect:     'slide',
-            direction:  'down',
-            'duration': 800
-         }
-      })
-      .dialog('open');
-   });
-});
-JAVASCRIPT;
-         print_r(Html::scriptBlock($script));
       }
    }
 

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -19,16 +19,17 @@ class PluginActualtimeTask extends CommonDBTM{
 
       global $CFG_GLPI;
       $item = $params['item'];
-      $text_restart = __('Restart', 'actualtime');
-      $text_pause = __('Pause', 'actualtime');
 
       switch ($item->getType()) {
          case 'TicketTask':
             if ($item->getID()) {
 
+               $task_id = $item->getID();
                $rand = mt_rand();
-               $buttons = self::checkTech($item->getID());
-               $time=self::totalEndTime($item->getID());
+               $buttons = self::checkTech($task_id);
+               $time = self::totalEndTime($task_id);
+               $text_restart = __('Restart', 'actualtime');
+               $text_pause = __('Pause', 'actualtime');
 
                if ($buttons) {
 
@@ -39,10 +40,11 @@ class PluginActualtimeTask extends CommonDBTM{
                   $action2 = '';
                   $color2 = 'gray';
                   $disabled2 = 'disabled';
+                  $timercolor = 'black';
 
                   if ($item->getField('state')==1) {
 
-                     if (self::checkTimerActive($item->getID())) {
+                     if (self::checkTimerActive($task_id)) {
 
                         $value1 = $text_pause;
                         $action1 = 'pause';
@@ -51,6 +53,7 @@ class PluginActualtimeTask extends CommonDBTM{
                         $action2 = 'end';
                         $color2 = 'red';
                         $disabled2 = '';
+                        $timercolor = 'red';
 
                      } else {
 
@@ -72,165 +75,32 @@ class PluginActualtimeTask extends CommonDBTM{
                   $html="<tr class='tab_bg_2'>";
                   $html.="<td colspan='2'></td>";
                   $html.="<td colspan='2'>";
-                  $html.="<div><input type='button' id='actualtime1$rand' name='update' task_id='".$item->getID()."'action='".$action1."' value='".$value1."' class='x-button x-button-main' style='background-color:".$color1.";color:white' $disabled1></div>";
-                  $html.="<div><input type='button' id='actualtime2$rand' name='update' task_id='".$item->getID()."'action='".$action2."' value='".__('End')."' class='x-button x-button-main' style='background-color:".$color2.";color:white' $disabled2></div>";
+                  // Objects of the same task have the same id beginning
+                  // as they all should be changed on actions in case multiple
+                  // windows of the same task is opened (list of tasks + modal)
+                  $html.="<div><input type='button' id='actualtime_button_{$task_id}_1_{$rand}' action='$action1' value='$value1' class='x-button x-button-main' style='background-color:$color1;color:white' $disabled1></div>";
+                  $html.="<div><input type='button' id='actualtime_button_{$task_id}_2_{$rand}' action='$action2' value='".__('End')."' class='x-button x-button-main' style='background-color:$color2;color:white' $disabled2></div>";
                   $html.="</td></tr>";
                   $html.="<tr class='tab_bg_2'>";
                   $html.="<td class='center'>".__("Start date")."</td><td class='center'>".__("Partial actual duration", 'actualtime')."</td>";
-                  $html.="<td>".__('Actual Duration', 'actualtime')." </td><td id='real_clock$rand'>".HTML::timestampToString($time)."</td>";
+                  $html.="<td>".__('Actual Duration', 'actualtime')." </td><td id='actualtime_timer_{$task_id}_{$rand}' style='color:{$timercolor}'>".HTML::timestampToString($time)."</td>";
                   $html.="</tr>";
-                  $html.="<tr id='actualtimeseg{$rand}'>";
+                  $html.="<tr id='actualtime_segment_{$task_id}_{$rand}'>";
                   $html.=self::getSegment($item->getID());
                   $html.="</tr>";
                   echo $html;
 
-                  $ajax_url=$CFG_GLPI['root_doc']."/plugins/actualtime/ajax/timer.php";
-                  $done=__('Done');
-                  $config = new PluginActualtimeConfig;
-                  if ($config->showTimerPopup()) {
-                     $showtimerpopup =  'true';
-                  } else {
-                     $showtimerpopup = 'false';
-                  }
-
                   $script=<<<JAVASCRIPT
-function showtaskform(e) {
-   e.preventDefault();
-   $('<div>')
-      .dialog({
-         modal:  true,
-         width:  'auto',
-         height: 'auto',
-      })
-      .load('{$ajax_url}?showform=true', function() {
-         $(this).dialog('option', 'position', ['center', 'center'] );
-      });
-}
 $(document).ready(function() {
-   var x;
-   if (!$("#message_result").length) {
-      $("body").append("<div id='message_result'></div>");
-   }
 
-   if ($("#timer{$rand}").length) {
-      $("#timer{$rand}").remove();
-   }
-
-   if ($("#actualtime1{$rand}").attr("action")=='pause') {
-      startCount($("#actualtime1{$rand}").attr("task_id"));
-   }
-
-   function startCount(id) {
-      $('#real_clock{$rand}').css('color','red');
-      jQuery.ajax({
-         type:     "POST",
-         url:      '{$ajax_url}',
-         dataType: 'json',
-         data:     {action: 'count', task_id: id},
-         success:  function (result) {
-            var time=result;
-            $('#real_clock{$rand}').text(timeToText(time, 3));
-            x=setInterval(function() {
-               time += 1;
-               $('#real_clock{$rand}').text(timeToText(time, 3));
-            },1000);
-         },
-      });
-   }
-
-   function endCount(time){
-      clearInterval(x);
-      // Correct real time clock with the actual data in database
-      $('#real_clock{$rand}').text(timeToText(time, 3));
-      $('#real_clock{$rand}').css('color','black');
-   }
-
-   $("#actualtime1{$rand}").click(function(event) {
-      buttonPressed($(this));
+   $("#actualtime_button_{$task_id}_1_{$rand}").click(function(event) {
+      actualtime_pressedButton($task_id, $(this).attr('action'));
    });
 
-   $("#actualtime2{$rand}").click(function(event) {
-      buttonPressed($(this));
+   $("#actualtime_button_{$task_id}_2_{$rand}").click(function(event) {
+      actualtime_pressedButton($task_id, $(this).attr('action'));
    });
 
-   function buttonPressed(btnobj) {
-      var id = btnobj.attr("task_id");
-      var val = btnobj.attr("action");
-      var time = {$time};
-      jQuery.ajax({
-         type:     "POST",
-         url:      '{$ajax_url}',
-         dataType: 'json',
-         data:     {action: val, task_id: id},
-         success:  function (result) {
-            if (result['class'] == 'info_msg') {
-               if (val == 'end' || val == 'pause') {
-                  if (val == 'end') {
-                     $("table:has(#actualtime2{$rand}) select[name='state']").val(2).trigger('change');
-                     $('#actualtime1{$rand}').attr('action','').css('background-color','gray').prop('disabled',true);
-                     $('#actualtime2{$rand}').attr('action','').css('background-color','gray').prop('disabled',true);
-                  } else {
-                     $('#actualtime1{$rand}').attr('value','$text_restart').attr('action','start').css('background-color','green').prop('disabled',false);
-                  }
-                  endCount(result['time']);
-                  $('#actualtimeseg{$rand}').html(result['html']);
-                  // remove timer popup
-                  $('[id^="actualtime_timer"]').remove();
-               } else if (val == 'start') {
-                  $('#actualtime1{$rand}').attr('value','$text_pause').attr('action','pause').css('background-color','orange').prop('disabled',false);
-                  $('#actualtime2{$rand}').attr('action','end').css('background-color','red').prop('disabled',false);
-                  startCount(id);
-                  if ({$showtimerpopup}) {
-                     // show timer popup
-                     showTimerPopup();
-                     return;
-                  }
-               }
-            }
-            $('#message_result').html(result['mensage']);
-            $('#message_result').attr('title', result['title']);
-            $(function() {
-               var _of = window;
-               var _at = 'right-20 bottom-20';
-               //calculate relative dialog position
-               $('.message_result').each(function() {
-                  var _this = $(this);
-                  if (_this.attr('aria-describedby') != 'message_result') {
-                     _of = _this;
-                     _at = 'right top-' + (10 + _this.outerHeight());
-                  }
-               });
-               $('#message_result').dialog({
-                  dialogClass: 'message_after_redirect ' + result['class'],
-                  minHeight:   40,
-                  minWidth:    200,
-                  position:    {
-                     my:        'right bottom',
-                     at:        _at,
-                     of:        _of,
-                     collision: 'none'
-                  },
-                  autoOpen:    false,
-                  show:        {
-                     effect:     'slide',
-                     direction:  'down',
-                     'duration': 800
-                  }
-               })
-               .dialog('open');
-               $(document.body).on('click', function(e) {
-                  if ($('#message_result').dialog('isOpen')
-                     && !$(e.target).is('.ui-dialog, a')
-                     && !$(e.target).closest('.ui-dialog').length) {
-                     $('#message_result').dialog('close');
-                     // redo focus on initial element
-                     e.target.focus();
-                  }
-               });
-            });
-         },
-      });
-   };
 });
 JAVASCRIPT;
                   echo Html::scriptBlock($script);
@@ -239,9 +109,9 @@ JAVASCRIPT;
 
                   $html="<tr class='tab_bg_2'>";
                   $html.="<td class='center'>".__("Start date")."</td><td class='center'>".__("Partial actual duration", 'actualtime')."</td>";
-                  $html.="<td>".__('Actual Duration', 'actualtime')." </td><td id='real_clock$rand'>".HTML::timestampToString($time)."</td>";
+                  $html.="<td>".__('Actual Duration', 'actualtime')." </td><td id='actualtime_timer_{$task_id}_{$rand}'>".HTML::timestampToString($time)."</td>";
                   $html.="</div></td></tr>";
-                  $html.="<tr id='actualtimeseg{$rand}'>";
+                  $html.="<tr id='actualtime_segment_{$task_id}_{$rand}'>";
                   $html.=self::getSegment($item->getID());
                   $html.="</tr>";
                   echo $html;
@@ -602,12 +472,14 @@ JAVASCRIPT;
    }
 
    static function postShowTab($params) {
-      $script=<<<JAVASCRIPT
+      if ($ticket_id = PluginActualtimetask::getTicket(Session::getLoginUserID())) {
+         $script=<<<JAVASCRIPT
 $(document).ready(function(){
-   showTimerPopup();
+   actualtime_showTimerPopup($ticket_id);
 });
 JAVASCRIPT;
-      echo Html::scriptBlock($script);
+         echo Html::scriptBlock($script);
+      }
    }
 
    static function install(Migration $migration) {

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -609,7 +609,7 @@ $(document).ready(function(){
 JAVASCRIPT;
       echo Html::scriptBlock($script);
    }
-      
+
    static function install(Migration $migration) {
       global $DB;
 

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -190,10 +190,15 @@ $(document).ready(function() {
                   }
                   endCount(result['realclock']);
                   $('#actualtimeseg{$rand}').html(result['html']);
+                  // remove timer popup
+                  $('[id^="actualtime_timer"]').remove();
                } else if (val == 'start') {
                   $('#actualtime1{$rand}').attr('value','$text_pause').attr('action','pause').css('background-color','orange').prop('disabled',false);
                   $('#actualtime2{$rand}').attr('action','end').css('background-color','red').prop('disabled',false);
                   startCount(id);
+                  // show timer popup
+                  showTimerPopup();
+                  return;
                }
             }
             $('#message_result').html(result['mensage']);

--- a/js/actualtime.js
+++ b/js/actualtime.js
@@ -29,6 +29,10 @@ function actualtime_showTaskForm(e){
       })
       .load(ajax_url + '?showform=true', function() {
          $(this).dialog('option', 'position', ['center', 'center'] );
+         var div = $(this).parent();
+         var of = div.offset();
+         div.css('position', 'fixed');
+         div.offset(of);
       });
 }
 
@@ -102,6 +106,12 @@ function actualtime_showTimerPopup(ticket) {
             })
             .dialog('open');
       });
+      setTimeout(function() {
+         // Transform in position:fixed to solve dialog bug
+         of = $("#actualtime_popup").parent().offset();
+         $("#actualtime_popup").parent().css('position', 'fixed');
+         $("#actualtime_popup").parent().offset(of);
+       }, 1000);
    }
 }
 

--- a/js/actualtime.js
+++ b/js/actualtime.js
@@ -1,18 +1,25 @@
-symb_d = '%dd';
-symb_day = '%d day';
-symb_days = '%d days';
-symb_h = '%dh';
-symb_hour = '%d hour';
-symb_hours = '%d hours';
-symb_min = '%dmin';
-symb_minute = '%d minute';
-symb_minutes = '%d minutes';
-symb_s = '%ds';
-symb_second = '%d second';
-symb_seconds = '%d seconds';
-ajax_url = '../plugins/actualtime/ajax/timer.php';
+var ajax_url = '../plugins/actualtime/ajax/timer.php';
+var timer;
+var popup_div = '';
+// Translations
+var symb_d = '%dd';
+var symb_day = '%d day';
+var symb_days = '%d days';
+var symb_h = '%dh';
+var symb_hour = '%d hour';
+var symb_hours = '%d hours';
+var symb_min = '%dmin';
+var symb_minute = '%d minute';
+var symb_minutes = '%d minutes';
+var symb_s = '%ds';
+var symb_second = '%d second';
+var symb_seconds = '%d seconds';
+var text_warning = 'Warning';
+var text_pause = 'Pause';
+var text_restart = 'Restart';
+var text_done = 'Done';
 
-function showtaskform(e){
+function actualtime_showTaskForm(e){
    e.preventDefault();
    $('<div>')
       .dialog({
@@ -25,7 +32,7 @@ function showtaskform(e){
       });
 }
 
-function timeToText(time, format) {
+function actualtime_timeToText(time, format) {
    var days = 0;
    var hours = 0;
    var minutes = 0;
@@ -57,7 +64,145 @@ function timeToText(time, format) {
    return text;
 }
 
-function showTimerPopup() {
+function actualtime_showTimerPopup(ticket) {
+   $("#actualtime_popup").remove();
+   // only if enabled in settings
+   if (popup_div) {
+      $("body").append(popup_div.replace(/%t/g, ticket));
+      $("#actualtime_popup").attr('title', text_warning);
+      $(function() {
+         var _of = window;
+         var _at = 'right-20 bottom-20';
+         //calculate relative dialog position
+         $('.message_result').each(function() {
+            var _this = $(this);
+            if (_this.attr('aria-describedby') != 'message_result') {
+               _of = _this;
+               _at = 'right top-' + (10 + _this.outerHeight());
+            }
+         });
+         $("#actualtime_popup")
+            .attr('title', text_warning)
+            .dialog({
+               dialogClass: 'message_after_redirect warn_msg',
+               minHeight:   40,
+               minWidth:    200,
+               position:    {
+                  my:        'right bottom',
+                  at:        _at,
+                  of:        _of,
+                  collision: 'none'
+               },
+               autoOpen:    false,
+               show:        {
+                  effect:     'slide',
+                  direction:  'down',
+                  'duration': 800
+               }
+            })
+            .dialog('open');
+      });
+   }
+}
+
+function actualtime_startCount(task, time) {
+   timer = setInterval(function() {
+      time += 1;
+      var timestr = actualtime_timeToText(time, 1);
+      $("[id^='actualtime_timer_" + task + "_']").text(timestr);
+      $("#actualtime_popup span").text(timestr);
+   },1000);
+}
+
+function actualtime_endCount(){
+   clearInterval(timer);
+}
+
+function actualtime_pressedButton(task, val) {
+   jQuery.ajax({
+      type:     "POST",
+      url:      ajax_url,
+      dataType: 'json',
+      data:     {action: val, task_id: task},
+      success:  function (result) {
+         if (result['class'] == 'info_msg') {
+            if (val == 'start') {
+               actualtime_startCount(task, result['time']);
+               $("[id^='actualtime_timer_" + task + "_']").css('color', 'red');
+               $("[id^='actualtime_button_" + task + "_1_']").attr('value', text_pause).attr('action', 'pause').css('background-color', 'orange').prop('disabled', false);
+               $("[id^='actualtime_button_" + task + "_2_']").attr('action', 'end').css('background-color', 'red').prop('disabled', false);
+               actualtime_showTimerPopup(result['ticket_id']);
+               return;
+            } else if ((val == 'end') || (val == 'pause')) {
+               actualtime_endCount();
+               $("#actualtime_popup").remove();
+               // Update all forms of this task (normal and modal)
+               $("[id^='actualtime_timer_" + task + "_']").css('color', 'black');
+               var timestr = actualtime_timeToText(result['time'], 1);
+               $("[id^='actualtime_timer_" + task + "_']").text(timestr);
+               $("[id^='actualtime_segment_" + task + "_']").html(result['segment']);
+               if (val == 'end') {
+                  // Update state fields also (as Done)
+                  $("span.state.state_1[onclick='change_task_state(" + task + ", this)']").attr('title',text_done).toggleClass('state_1 state_2');
+                  $("input[type='hidden'][name='id'][value='" + task + "']").closest("table#mainformtable").find("select[name='state']").val(2).trigger('change');
+                  $("[id^='actualtime_button_" + task + "_']").attr('action', '').css('background-color', 'gray').prop('disabled', true);
+               } else {
+                  $("[id^='actualtime_button_" + task + "_1_']").attr('value', text_restart).attr('action', 'start').css('background-color', 'green').prop('disabled', false);
+               }
+            }
+         }
+         $('#message_result').html(result['mensage']);
+         $('#message_result').attr('title', result['title']);
+         $(function() {
+            var _of = window;
+            var _at = 'right-20 bottom-20';
+            //calculate relative dialog position
+            $('.message_result').each(function() {
+               var _this = $(this);
+               if (_this.attr('aria-describedby') != 'message_result') {
+                  _of = _this;
+                  _at = 'right top-' + (10 + _this.outerHeight());
+               }
+            });
+            $('#message_result').dialog({
+               dialogClass: 'message_after_redirect ' + result['class'],
+               minHeight:   40,
+               minWidth:    200,
+               position:    {
+                  my:        'right bottom',
+                  at:        _at,
+                  of:        _of,
+                  collision: 'none'
+               },
+               autoOpen:    false,
+               show:        {
+                  effect:     'slide',
+                  direction:  'down',
+                  'duration': 800
+               }
+            })
+            .dialog('open');
+            $(document.body).on('click', function(e) {
+               if ($('#message_result').dialog('isOpen')
+                  && !$(e.target).is('.ui-dialog, a')
+                  && !$(e.target).closest('.ui-dialog').length) {
+                  $('#message_result').dialog('close');
+                  // redo focus on initial element
+                  e.target.focus();
+               }
+            });
+         });
+      }
+   });
+}
+
+$(document).ready(function(){
+
+   if (!$("#message_result").length) {
+      $("body").append("<div id='message_result'></div>");
+   }
+
+   // Initialize
    jQuery.ajax({
       type:     'GET',
       url:      ajax_url + '?footer',
@@ -75,54 +220,17 @@ function showTimerPopup() {
          symb_s = result['symb_s'];
          symb_second = result['symb_second'];
          symb_seconds = result['symb_seconds'];
+         text_warning = result['text_warning'];
+         text_pause = result['text_pause'];
+         text_restart = result['text_restart'];
+         text_done = result['text_done'];
+         popup_div = result['popup_div'];
 
-         $("[id^='actualtime_timer']").remove();
-
-         if (result['task_id']) {
-            $("body").append(result['div']);
-            var time = result['time'];
-            var timerdiv = $("#actualtime_timer" + result['rand']);
-            timer = setInterval(function() {
-               time += 1;
-               timerdiv.find('span').text(timeToText(time, 1));
-            },1000);
-            timerdiv.attr('title', result['warning']);
-            $(function() {
-               var _of = window;
-               var _at = 'right-20 bottom-20';
-               //calculate relative dialog position
-               $('.message_result').each(function() {
-                  var _this = $(this);
-                  if (_this.attr('aria-describedby') != 'message_result') {
-                     _of = _this;
-                     _at = 'right top-' + (10 + _this.outerHeight());
-                  }
-               });
-               timerdiv
-                  .dialog({
-                     dialogClass: 'message_after_redirect warn_msg',
-                     minHeight:   40,
-                     minWidth:    200,
-                     position:    {
-                        my:        'right bottom',
-                        at:        _at,
-                        of:        _of,
-                        collision: 'none'
-                     },
-                     autoOpen:    false,
-                     show:        {
-                        effect:     'slide',
-                        direction:  'down',
-                        'duration': 800
-                     }
-                  })
-                  .dialog('open');
-            });
+         if (result['ticket_id']) {
+            actualtime_startCount(result['task_id'], result['time']);
+            actualtime_showTimerPopup(result['ticket_id']);
          }
       }
    });
-}
 
-$(document).ready(function(){
-    showTimerPopup();
 });

--- a/js/actualtime.js
+++ b/js/actualtime.js
@@ -1,0 +1,126 @@
+symb_d = '%dd';
+symb_day = '%d day';
+symb_days = '%d days';
+symb_h = '%dh';
+symb_hour = '%d hour';
+symb_hours = '%d hours';
+symb_min = '%dmin';
+symb_minute = '%d minute';
+symb_minutes = '%d minutes';
+symb_s = '%ds';
+symb_second = '%d second';
+symb_seconds = '%d seconds';
+ajax_url = '../plugins/actualtime/ajax/timer.php';
+
+function showtaskform(e){
+   e.preventDefault();
+   $('<div>')
+      .dialog({
+         modal:  true,
+         width:  'auto',
+         height: 'auto',
+      })
+      .load(ajax_url + '?showform=true', function() {
+         $(this).dialog('option', 'position', ['center', 'center'] );
+      });
+}
+
+function timeToText(time, format) {
+   var days = 0;
+   var hours = 0;
+   var minutes = 0;
+   var distance = time;
+   var seconds = distance % 60;
+   distance -= seconds;
+   var text = (format == 3 ? (seconds > 1 ? symb_seconds : symb_second) : symb_s).replace('%d', seconds);;
+   if (distance > 0) {
+      minutes = (distance % 3600) / 60;
+      distance -= minutes * 60;
+      text = (format == 3 ? (minutes > 1 ? symb_minutes : symb_minute) : symb_min).replace('%d', minutes) + ' ' + text;
+      if (distance > 0) {
+         if (format == 2) {
+            hours = distance / 3600;
+            if (minutes < 10) {
+               minutes = '0' + minutes;
+            }
+            return symb_h.replace('%d', hours) + (seconds > 0 ? symb_min.replace('%d', minutes) + symb_s.replace('%d', (seconds < 10 ? '0' : '') + seconds) : minutes);
+         }
+         hours = (distance % 86400) / 3600;
+         distance -= hours * 3600;
+         text = (format == 3 ? (hours > 1 ? symb_hours : symb_hour) : symb_h).replace('%d', hours) + ' ' + text;
+         if (distance > 0) {
+            days = distance / 86400;
+            text = (format == 3 ? (days > 1 ? symb_days : symb_day) : symb_d).replace('%d', days) + ' ' + text;
+         }
+      }
+   }
+   return text;
+}
+
+$(document).ready(function(){
+   jQuery.ajax({
+      type:     'GET',
+      url:      ajax_url + '?footer',
+      dataType: 'json',
+      success: function (result) {
+         symb_d = result['symb_d']; 
+         symb_day = result['symb_day']; 
+         symb_days = result['symb_days']; 
+         symb_h = result['symb_h']; 
+         symb_hour = result['symb_hour']; 
+         symb_hours = result['symb_hours']; 
+         symb_min = result['symb_min']; 
+         symb_minute = result['symb_minute']; 
+         symb_minutes = result['symb_minutes']; 
+         symb_s = result['symb_s']; 
+         symb_second = result['symb_second']; 
+         symb_seconds = result['symb_seconds']; 
+
+         if ($("#timer" + result['rand']).length) {
+            $("#timer" + result['rand']).remove();
+         }
+
+         if (result['task_id']) {
+            $("body").append(result['div']);
+            var time = result['time'];
+            var timerdiv = $("#timer" + result['rand']);
+            timer = setInterval(function() {
+               time += 1;
+               timerdiv.find('span').text(timeToText(time, 10));
+            },1000);
+            timerdiv.attr('title', result['warning']);
+            $(function() {
+               var _of = window;
+               var _at = 'right-20 bottom-20';
+               //calculate relative dialog position
+               $('.message_result').each(function() {
+                  var _this = $(this);
+                  if (_this.attr('aria-describedby') != 'message_result') {
+                     _of = _this;
+                     _at = 'right top-' + (10 + _this.outerHeight());
+                  }
+               });
+               timerdiv
+                  .dialog({
+                     dialogClass: 'message_after_redirect warn_msg',
+                     minHeight:   40,
+                     minWidth:    200,
+                     position:    {
+                        my:        'right bottom',
+                        at:        _at,
+                        of:        _of,
+                        collision: 'none'
+                     },
+                     autoOpen:    false,
+                     show:        {
+                        effect:     'slide',
+                        direction:  'down',
+                        'duration': 800
+                     }
+                  })
+                  .dialog('open');
+            });
+         }
+      }
+   });
+});

--- a/js/actualtime.js
+++ b/js/actualtime.js
@@ -63,18 +63,18 @@ function showTimerPopup() {
       url:      ajax_url + '?footer',
       dataType: 'json',
       success: function (result) {
-         symb_d = result['symb_d']; 
-         symb_day = result['symb_day']; 
-         symb_days = result['symb_days']; 
-         symb_h = result['symb_h']; 
-         symb_hour = result['symb_hour']; 
-         symb_hours = result['symb_hours']; 
-         symb_min = result['symb_min']; 
-         symb_minute = result['symb_minute']; 
-         symb_minutes = result['symb_minutes']; 
-         symb_s = result['symb_s']; 
-         symb_second = result['symb_second']; 
-         symb_seconds = result['symb_seconds']; 
+         symb_d = result['symb_d'];
+         symb_day = result['symb_day'];
+         symb_days = result['symb_days'];
+         symb_h = result['symb_h'];
+         symb_hour = result['symb_hour'];
+         symb_hours = result['symb_hours'];
+         symb_min = result['symb_min'];
+         symb_minute = result['symb_minute'];
+         symb_minutes = result['symb_minutes'];
+         symb_s = result['symb_s'];
+         symb_second = result['symb_second'];
+         symb_seconds = result['symb_seconds'];
 
          $("[id^='actualtime_timer']").remove();
 

--- a/js/actualtime.js
+++ b/js/actualtime.js
@@ -57,7 +57,7 @@ function timeToText(time, format) {
    return text;
 }
 
-$(document).ready(function(){
+function showTimerPopup() {
    jQuery.ajax({
       type:     'GET',
       url:      ajax_url + '?footer',
@@ -76,14 +76,12 @@ $(document).ready(function(){
          symb_second = result['symb_second']; 
          symb_seconds = result['symb_seconds']; 
 
-         if ($("#timer" + result['rand']).length) {
-            $("#timer" + result['rand']).remove();
-         }
+         $("[id^='actualtime_timer']").remove();
 
          if (result['task_id']) {
             $("body").append(result['div']);
             var time = result['time'];
-            var timerdiv = $("#timer" + result['rand']);
+            var timerdiv = $("#actualtime_timer" + result['rand']);
             timer = setInterval(function() {
                time += 1;
                timerdiv.find('span').text(timeToText(time, 10));
@@ -123,4 +121,8 @@ $(document).ready(function(){
          }
       }
    });
+}
+
+$(document).ready(function(){
+    showTimerPopup();
 });

--- a/js/actualtime.js
+++ b/js/actualtime.js
@@ -84,7 +84,7 @@ function showTimerPopup() {
             var timerdiv = $("#actualtime_timer" + result['rand']);
             timer = setInterval(function() {
                time += 1;
-               timerdiv.find('span').text(timeToText(time, 10));
+               timerdiv.find('span').text(timeToText(time, 1));
             },1000);
             timerdiv.attr('title', result['warning']);
             $(function() {

--- a/setup.php
+++ b/setup.php
@@ -79,7 +79,7 @@ function plugin_init_actualtime() {
       $PLUGIN_HOOKS['post_item_form']['actualtime'] = ['PluginActualtimeTask', 'postForm'];
       $PLUGIN_HOOKS['show_item_stats']['actualtime'] = ['Ticket'=> 'plugin_activetime_item_stats'];
       $PLUGIN_HOOKS['pre_item_update']['actualtime'] = ['TicketTask'=>'plugin_activetime_item_update'];
-      $PLUGIN_HOOKS['post_show_item']['actualtime'] = ['PluginActualtimeTask', 'postShowItem'];
+      $PLUGIN_HOOKS['add_javascript']['actualtime'] = 'js/actualtime.js';
 
    }
 }

--- a/setup.php
+++ b/setup.php
@@ -80,6 +80,7 @@ function plugin_init_actualtime() {
       $PLUGIN_HOOKS['show_item_stats']['actualtime'] = ['Ticket'=> 'plugin_activetime_item_stats'];
       $PLUGIN_HOOKS['pre_item_update']['actualtime'] = ['TicketTask'=>'plugin_activetime_item_update'];
       $PLUGIN_HOOKS['add_javascript']['actualtime'] = 'js/actualtime.js';
+      $PLUGIN_HOOKS['post_show_tab']['actualtime'] = ['PluginActualtimeTask', 'postShowTab'];
 
    }
 }

--- a/setup.php
+++ b/setup.php
@@ -1,5 +1,5 @@
 <?php
-define ('PLUGIN_ACTUALTIME_VERSION', '1.1.1');
+define ('PLUGIN_ACTUALTIME_VERSION', '1.1.2');
 // Minimal GLPI version, inclusive
 define("PLUGIN_ACTUALTIME_MIN_GLPI", "9.3.0");
 // Maximum GLPI version, exclusive
@@ -80,7 +80,11 @@ function plugin_init_actualtime() {
       $PLUGIN_HOOKS['show_item_stats']['actualtime'] = ['Ticket'=> 'plugin_activetime_item_stats'];
       $PLUGIN_HOOKS['pre_item_update']['actualtime'] = ['TicketTask'=>'plugin_activetime_item_update'];
       $PLUGIN_HOOKS['add_javascript']['actualtime'] = 'js/actualtime.js';
-      $PLUGIN_HOOKS['post_show_tab']['actualtime'] = ['PluginActualtimeTask', 'postShowTab'];
+
+      if ($config->showTimerPopup()) {
+         // This hook is not needed if not showing popup
+         $PLUGIN_HOOKS['post_show_tab']['actualtime'] = ['PluginActualtimeTask', 'postShowTab'];
+      }
 
    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,8 +11,13 @@ include GLPI_ROOT . "/inc/includes.php";
 include_once GLPI_ROOT . '/tests/GLPITestCase.php';
 include_once GLPI_ROOT . '/tests/DbTestCase.php';
 
+require_once GLPI_ROOT . '/plugins/actualtime/setup.php';
+
 //install plugin
 $plugin = new \Plugin();
+//Glpi 9.4 does not initialize plugin table, so new plugins will not show
+//until you navigate to Plugins menu (let's force it, then)
+$plugin->checkStates(true);
 $plugin->getFromDBbyDir('actualtime');
 
 //check from prerequisites as Plugin::install() does not!

--- a/tests/units/PluginActualtimeConfig.php
+++ b/tests/units/PluginActualtimeConfig.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace tests\units;
+
+use atoum;
+
+class PluginActualtimeConfig extends atoum {
+
+   public function testRightname() {
+      $this
+         ->given($conf = $this->getTestedClassName())
+            ->string($conf::$rightname)
+               ->isEqualTo('config');
+   }
+
+   public function testGetTypeName() {
+      $this
+         ->if($class = $this->testedClass->getClass())
+         ->then
+            ->string($class::getTypeName())
+               ->isNotEmpty();
+   }
+
+   public function testGetConfig() {
+      $this
+         ->given($this->newTestedInstance)
+            ->object($this->testedInstance->getConfig())
+               ->isInstanceOfTestedClass();
+   }
+
+   public function testIsEnabled() {
+      $this
+         ->given($this->newTestedInstance)
+            ->boolean($this->testedInstance->isEnabled())
+               ->isTrue();
+   }
+
+   public function testShowTimerPopup() {
+      $this
+         ->given($this->newTestedInstance)
+            ->boolean($this->testedInstance->showTimerPopup())
+               ->isTrue();
+   }
+
+   public function testCanView() {
+      $this
+         ->given($this->newTestedInstance)
+            ->boolean($this->testedInstance->canView())
+               ->isFalse();
+   }
+
+   public function testCanCreate() {
+      $this
+         ->given($this->newTestedInstance)
+            ->boolean($this->testedInstance->canCreate())
+               ->isFalse();
+   }
+
+}

--- a/tests/units/PluginActualtimeTask.php
+++ b/tests/units/PluginActualtimeTask.php
@@ -6,6 +6,13 @@ use atoum;
 
 class PluginActualtimeTask extends atoum {
 
+   public function testRightname() {
+      $this
+         ->given($conf = $this->getTestedClassName())
+            ->string($conf::$rightname)
+               ->isEqualTo('task');
+   }
+
    public function testGetTypeName() {
       $this
          ->if($class = $this->testedClass->getClass())


### PR DESCRIPTION
Solving bug #24 , transfering all javascript (buttons, modal popup messages, modal task form) to actualtime.js, added in ALL PAGES with add-javascript hook, instead of post-show-item. This way, the pop-up timer will be shown on every page (instead of only on item lists), and will appear only once (instead of one pop-up for each item on the list).

jQuery updates optimized to avoid repeating code and to update all visible timers, buttons and statistics at once: on closed task in task list, on opened task form in task list, on opened task form in modal window and also the timer on the pop-up modal warning window. All visible timers will be synchronized also with this optimized code.

(also Travis CI configuration updated to validate code installed in the new 9.4/master branch in Glpi)