### PR TITLE
Auto open task edit form in some circunstances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ before_script:
   - composer self-update
   - composer require --dev atoum/atoum
   - git clone --depth=1 https://github.com/glpi-project/glpi -b $GLPIVER ../glpi && cd ../glpi
-  - composer install --optimize-autoloader --no-dev
   - sed -e '/"php":/d' -i composer.json
+  - sed -i 's/CssMin/cssmin/;s/Faker/Faker/;s/vfsStream/vfsstream/' composer.json
+  - composer install --optimize-autoloader --no-dev
   - rm -f composer.lock
   - mysql -u root -e 'create database glpitest;'
   # Both 9.3 and 9.4:
@@ -36,7 +37,7 @@ script:
   - ./vendor/bin/atoum --debug -bf tests/bootstrap.php -d tests/units/
 
 
-# Permit failure on Glpi 9.4 until fix test environment
+# Permit failure on PHP nightly until Travis fix missing gd extension
 matrix:
   exclude:
     - php: 5.6

--- a/ajax/timer.php
+++ b/ajax/timer.php
@@ -26,9 +26,9 @@ if (isset($_POST["action"])) {
             if (! PluginActualtimeTask::checkUserFree(Session::getLoginUserID())) {
 
                // action=start, timer=off, current user is alerady using timer
-               $opcional=PluginActualtimeTask::getTicket(Session::getLoginUserID());
+               $ticket_id = PluginActualtimeTask::getTicket(Session::getLoginUserID());
                $result=[
-                  'mensage' => __("You are already doing a task", 'actualtime')." <a onclick='showtaskform(event)' href='/front/ticket.form.php?id=".$opcional."'>".__("Ticket")."</a>",
+                  'mensage' => __("You are already doing a task", 'actualtime')." <a onclick='actualtime_showTaskForm(event)' href='/front/ticket.form.php?id=" . $ticket_id . "'>" . __("Ticket") . "$ticket_id</a>",
                   'title'   => __('Warning'),
                   'class'   => 'warn_msg',
                ];

--- a/hook.php
+++ b/hook.php
@@ -27,12 +27,16 @@ function plugin_actualtime_install() {
    return true;
 }
 
-function plugin_activetime_item_stats($item) {
+function plugin_actualtime_item_stats($item) {
    PluginActualtimeTask::showStats($item);
 }
 
-function plugin_activetime_item_update($item) {
+function plugin_actualtime_item_update($item) {
    PluginActualtimeTask::preUpdate($item);
+}
+
+function plugin_actualtime_item_add($item) {
+   PluginActualtimeTask::afterAdd($item);
 }
 
 /**

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -89,14 +89,19 @@ class PluginActualtimeConfig extends CommonDBTM {
       echo "</td>";
       echo "</tr>";
 
-      echo "<tr class='tab_bg_1' name='optional$rand' $style>
-         <td>" . __("Automatically open new created tasks", "actualtime") . "</td><td>";
+      echo "<tr class='tab_bg_1' name='optional$rand' $style>";
+      echo "<td>" . __("Automatically open new created tasks", "actualtime") . "</td><td>";
       Dropdown::showYesNo('autoopennew', $this->autoOpenNew(), -1);
       echo "</td>";
       echo "</tr>";
 
-      echo "<tr class='tab_bg_1' align='center'>";
+      echo "<tr class='tab_bg_1' name='optional$rand' $style>";
+      echo "<td>" . __("Automatically open task with timer running", "actualtime") . "</td><td>";
+      Dropdown::showYesNo('autoopenrunning', $this->autoOpenRunning(), -1);
+      echo "</td>";
+      echo "</tr>";
 
+      echo "<tr class='tab_bg_1' align='center'>";
       $this->showFormButtons(['candel'=>false]);
    }
 
@@ -137,13 +142,22 @@ class PluginActualtimeConfig extends CommonDBTM {
    }
 
    /**
-    * Auto open the form for the task with a currently running timer
-    * when listing tickets' tasks?
+    * Auto open the form for the task that was just created (new tasks)?
     *
     * @return boolean
     */
    function autoOpenNew() {
       return ($this->fields['autoopennew'] ? true : false);
+   }
+
+   /**
+    * Auto open the form for the task with a currently running timer
+    * when listing tickets' tasks?
+    *
+    * @return boolean
+    */
+   function autoOpenRunning() {
+      return ($this->fields['autoopenrunning'] ? true : false);
    }
 
    static function install(Migration $migration) {
@@ -158,6 +172,7 @@ class PluginActualtimeConfig extends CommonDBTM {
                       `enable` boolean NOT NULL DEFAULT true,
                       `showtimerpopup` boolean NOT NULL DEFAULT true,
                       `autoopennew` boolean NOT NULL DEFAULT false,
+                      `autoopenrunning` boolean NOT NULL DEFAULT false,
                       PRIMARY KEY (`id`)
                    )
                    ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
@@ -165,7 +180,8 @@ class PluginActualtimeConfig extends CommonDBTM {
       }
 
       if ($DB->tableExists($table)) {
-         if (! $DB->fieldExists($table,'showtimerpopup')) {
+         if (! $DB->fieldExists($table, 'showtimerpopup')) {
+            // Add new field showtimerpopup
             $migration->addField(
                $table,
                'showtimerpopup',
@@ -177,7 +193,7 @@ class PluginActualtimeConfig extends CommonDBTM {
                ]
             );
          }
-         if (! $DB->fieldExists($table,'autoopennew')) {
+         if (! $DB->fieldExists($table, 'autoopennew')) {
             // Add new field autoopennew
             $migration->addField(
                $table,
@@ -190,7 +206,19 @@ class PluginActualtimeConfig extends CommonDBTM {
                ]
             );
          }
-
+         if (! $DB->fieldExists($table, 'autoopenrunning')) {
+            // Add new field autoopenrunning
+            $migration->addField(
+               $table,
+               'autoopenrunning',
+               'boolean',
+               [
+                  'update' => false,
+                  'value'  => false,
+                  'after'  => 'autoopennew',
+               ]
+            );
+         }
          // Create default record (if it does not exist)
          $reg = $DB->request($table);
          if (! count($reg)) {

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -89,10 +89,11 @@ class PluginActualtimeConfig extends CommonDBTM {
       echo "</td>";
       echo "</tr>";
 
-      //echo "<tr class='tab_bg_1' name='optional$rand' $style>
-      //   <td>example settings 2";
-      //echo "</td>";
-      //echo "</tr>";
+      echo "<tr class='tab_bg_1' name='optional$rand' $style>
+         <td>" . __("Automatically open new created tasks", "actualtime") . "</td><td>";
+      Dropdown::showYesNo('autoopennew', $this->autoOpenNew(), -1);
+      echo "</td>";
+      echo "</tr>";
 
       echo "<tr class='tab_bg_1' align='center'>";
 
@@ -135,6 +136,16 @@ class PluginActualtimeConfig extends CommonDBTM {
       return ($this->fields['showtimerpopup'] ? true : false);
    }
 
+   /**
+    * Auto open the form for the task with a currently running timer
+    * when listing tickets' tasks?
+    *
+    * @return boolean
+    */
+   function autoOpenNew() {
+      return ($this->fields['autoopennew'] ? true : false);
+   }
+
    static function install(Migration $migration) {
       global $DB;
 
@@ -145,6 +156,8 @@ class PluginActualtimeConfig extends CommonDBTM {
          $query = "CREATE TABLE IF NOT EXISTS $table (
                       `id` int(11) NOT NULL auto_increment,
                       `enable` boolean NOT NULL DEFAULT true,
+                      `showtimerpopup` boolean NOT NULL DEFAULT true,
+                      `autoopennew` boolean NOT NULL DEFAULT false,
                       PRIMARY KEY (`id`)
                    )
                    ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
@@ -152,27 +165,41 @@ class PluginActualtimeConfig extends CommonDBTM {
       }
 
       if ($DB->tableExists($table)) {
+         if (! $DB->fieldExists($table,'showtimerpopup')) {
+            $migration->addField(
+               $table,
+               'showtimerpopup',
+               'boolean',
+               [
+                  'update' => true,
+                  'value'  => true,
+                  'after' => 'enable'
+               ]
+            );
+         }
+         if (! $DB->fieldExists($table,'autoopennew')) {
+            // Add new field autoopennew
+            $migration->addField(
+               $table,
+               'autoopennew',
+               'boolean',
+               [
+                  'update' => false,
+                  'value'  => false,
+                  'after'  => 'showtimerpopup',
+               ]
+            );
+         }
 
          // Create default record (if it does not exist)
          $reg = $DB->request($table);
          if (! count($reg)) {
             $DB->insert(
                $table, [
-                  'enable' => 1
+                  'enable' => true
                ]
             );
          }
-
-         $migration->addField(
-            $table,
-            'showtimerpopup',
-            'boolean',
-            [
-               'update' => 1,
-               'value'  => 1,
-               'after' => 'enable'
-            ]
-         );
 
       }
 

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -26,7 +26,7 @@ class PluginActualtimeTask extends CommonDBTM{
 
                $task_id = $item->getID();
                $rand = mt_rand();
-               $buttons = self::checkTech($task_id);
+               $buttons = (self::checkTech($task_id) && $item->can($task_id, UPDATE));
                $time = self::totalEndTime($task_id);
                $text_restart = __('Restart', 'actualtime');
                $text_pause = __('Pause', 'actualtime');

--- a/js/actualtime.js
+++ b/js/actualtime.js
@@ -111,7 +111,7 @@ function actualtime_showTimerPopup(ticket) {
          of = $("#actualtime_popup").parent().offset();
          $("#actualtime_popup").parent().css('position', 'fixed');
          $("#actualtime_popup").parent().offset(of);
-       }, 1000);
+      }, 1000);
    }
 }
 

--- a/setup.php
+++ b/setup.php
@@ -88,6 +88,7 @@ function plugin_init_actualtime() {
       }
 
       if ($config->autoOpenNew()) {
+          // This hook is not needed if not opening new tasks automatically
           $PLUGIN_HOOKS['item_add']['actualtime'] = ['TicketTask'=>'plugin_actualtime_item_add'];
       }
 

--- a/setup.php
+++ b/setup.php
@@ -77,13 +77,18 @@ function plugin_init_actualtime() {
       }
 
       $PLUGIN_HOOKS['post_item_form']['actualtime'] = ['PluginActualtimeTask', 'postForm'];
-      $PLUGIN_HOOKS['show_item_stats']['actualtime'] = ['Ticket'=> 'plugin_activetime_item_stats'];
-      $PLUGIN_HOOKS['pre_item_update']['actualtime'] = ['TicketTask'=>'plugin_activetime_item_update'];
+      $PLUGIN_HOOKS['show_item_stats']['actualtime'] = ['Ticket'=> 'plugin_actualtime_item_stats'];
+      $PLUGIN_HOOKS['pre_item_update']['actualtime'] = ['TicketTask'=>'plugin_actualtime_item_update'];
+      $PLUGIN_HOOKS['post_show_item']['actualtime'] = ['PluginActualtimeTask', 'postShowItem'];
       $PLUGIN_HOOKS['add_javascript']['actualtime'] = 'js/actualtime.js';
 
       if ($config->showTimerPopup()) {
          // This hook is not needed if not showing popup
          $PLUGIN_HOOKS['post_show_tab']['actualtime'] = ['PluginActualtimeTask', 'postShowTab'];
+      }
+
+      if ($config->autoOpenNew()) {
+          $PLUGIN_HOOKS['item_add']['actualtime'] = ['TicketTask'=>'plugin_actualtime_item_add'];
       }
 
    }

--- a/tests/units/PluginActualtimeConfig.php
+++ b/tests/units/PluginActualtimeConfig.php
@@ -42,6 +42,20 @@ class PluginActualtimeConfig extends atoum {
                ->isTrue();
    }
 
+   public function testAutoOpenNew() {
+      $this
+         ->given($this->newTestedInstance)
+            ->boolean($this->testedInstance->autoOpenNew())
+               ->isFalse();
+   }
+
+   public function testAutoOpenRunning() {
+      $this
+         ->given($this->newTestedInstance)
+            ->boolean($this->testedInstance->autoOpenRunning())
+               ->isFalse();
+   }
+
    public function testCanView() {
       $this
          ->given($this->newTestedInstance)


### PR DESCRIPTION
According to issue #4 , this will facilitate technicians that opens a task and need to immediately start the timer. And also quickly get to the current running task when listing all tasks (it is already possible to open a modal window with the current running task, clicking on the pop-up timer).

Two new settings are available, so plugin must be upgraded on Setup - Plugins page (to enable that easily, the development version is set to 1.1.3).