### PR TITLE
Control which interface can see timers and include closed box timer

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -83,16 +83,27 @@ class PluginActualtimeConfig extends CommonDBTM {
 
       // Include lines with other settings
 
+      $values = [
+         0 => __('In Standard interface only (default)', 'actualtime'),
+         1 => __('Both in Standard and Helpdesk interfaces', 'actualtime'),
+      ];
+      echo "<tr class='tab_bg_1' name='optional$rand' $style>";
+      echo "<td>" . __("Enable timer on tasks", "actualtime") . "</td><td>";
+      Dropdown::showFromArray(
+         'displayinfofor',
+         $values,
+         [
+            'value' => $this->fields['displayinfofor']
+         ]
+      );
+      echo "</td>";
+      echo "</tr>";
+
       echo "<tr class='tab_bg_1' name='optional$rand' $style>";
       echo "<td>" . __("Display pop-up window with current running timer", "actualtime") . "</td><td>";
       Dropdown::showYesNo('showtimerpopup', $this->showTimerPopup(), -1);
       echo "</td>";
       echo "</tr>";
-
-      //echo "<tr class='tab_bg_1' name='optional$rand' $style>
-      //   <td>example settings 2";
-      //echo "</td>";
-      //echo "</tr>";
 
       echo "<tr class='tab_bg_1' align='center'>";
 
@@ -118,7 +129,7 @@ class PluginActualtimeConfig extends CommonDBTM {
    }
 
    /**
-    * Plugin is enabled in plugin settings?
+    * Is plugin enabled in plugin settings?
     *
     * @return boolean
     */
@@ -127,12 +138,21 @@ class PluginActualtimeConfig extends CommonDBTM {
    }
 
    /**
-    * Timer pop-up display on every page enabled in plugin settings?
+    * Is displaying timer pop-up on every page enabled in plugin settings?
     *
     * @return boolean
     */
    function showTimerPopup() {
       return ($this->fields['showtimerpopup'] ? true : false);
+   }
+
+   /**
+    * Is actual time information (timers) shown also in Helpdesk interface?
+    *
+    * @return boolean
+    */
+   function showInHelpdesk() {
+      return ($this->fields['displayinfofor'] == 1);
    }
 
    static function install(Migration $migration) {
@@ -145,6 +165,8 @@ class PluginActualtimeConfig extends CommonDBTM {
          $query = "CREATE TABLE IF NOT EXISTS $table (
                       `id` int(11) NOT NULL auto_increment,
                       `enable` boolean NOT NULL DEFAULT true,
+                      `showtimerpopup` boolean NOT NULL DEFAULT true,
+                      `displayinfofor` smallint NOT NULL DEFAULT 0,
                       PRIMARY KEY (`id`)
                    )
                    ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
@@ -158,7 +180,7 @@ class PluginActualtimeConfig extends CommonDBTM {
          if (! count($reg)) {
             $DB->insert(
                $table, [
-                  'enable' => 1
+                  'enable' => true
                ]
             );
          }
@@ -168,9 +190,23 @@ class PluginActualtimeConfig extends CommonDBTM {
             'showtimerpopup',
             'boolean',
             [
-               'update' => 1,
-               'value'  => 1,
+               'update' => true,
+               'value'  => true,
                'after' => 'enable'
+            ]
+         );
+
+         // For whom the actualtime timers are displayed?
+         // 0 - Only in standard/central interface (default)
+         // 1 - Both in standard and helpdesk interfaces
+         $migration->addField(
+            $table,
+            'displayinfofor',
+            'smallint',
+            [
+               'update' => 0,
+               'value'  => 0,
+               'after' => 'showtimerpopup'
             ]
          );
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -105,6 +105,12 @@ class PluginActualtimeConfig extends CommonDBTM {
       echo "</td>";
       echo "</tr>";
 
+      echo "<tr class='tab_bg_1' name='optional$rand' $style>";
+      echo "<td>" . __("Display actual time in closed task box ('Processing ticket' list)", "actualtime") . "</td><td>";
+      Dropdown::showYesNo('showtimerinbox', $this->showTimerInBox(), -1);
+      echo "</td>";
+      echo "</tr>";
+
       echo "<tr class='tab_bg_1' align='center'>";
 
       $this->showFormButtons(['candel'=>false]);
@@ -155,6 +161,15 @@ class PluginActualtimeConfig extends CommonDBTM {
       return ($this->fields['displayinfofor'] == 1);
    }
 
+   /**
+    * Is timer shown in closed task box at 'Actions historical' page?
+    *
+    * @return boolean
+    */
+   function showTimerInBox() {
+      return ($this->fields['showtimerinbox'] ? true : false);
+   }
+
    static function install(Migration $migration) {
       global $DB;
 
@@ -167,6 +182,7 @@ class PluginActualtimeConfig extends CommonDBTM {
                       `enable` boolean NOT NULL DEFAULT true,
                       `showtimerpopup` boolean NOT NULL DEFAULT true,
                       `displayinfofor` smallint NOT NULL DEFAULT 0,
+                      `showtimerinbox` boolean NOT NULL DEFAULT true,
                       PRIMARY KEY (`id`)
                    )
                    ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
@@ -207,6 +223,17 @@ class PluginActualtimeConfig extends CommonDBTM {
                'update' => 0,
                'value'  => 0,
                'after' => 'showtimerpopup'
+            ]
+         );
+
+         $migration->addField(
+            $table,
+            'showtimerinbox',
+            'boolean',
+            [
+               'update' => true,
+               'value'  => true,
+               'after' => 'displayinfofor'
             ]
          );
 

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -502,6 +502,10 @@ JAVASCRIPT;
    static function postShowItem($params) {
 
       $item = $params['item'];
+      if (! is_object($item) || ! method_exists($item, 'getType')) {
+         // Sometimes, params['item'] is just an array, like 'Solution'
+         return;
+      }
       switch ($item->getType()) {
          case 'TicketTask':
 

--- a/js/actualtime.js
+++ b/js/actualtime.js
@@ -111,7 +111,7 @@ function actualtime_showTimerPopup(ticket) {
          of = $("#actualtime_popup").parent().offset();
          $("#actualtime_popup").parent().css('position', 'fixed');
          $("#actualtime_popup").parent().offset(of);
-       }, 1000);
+      }, 1000);
    }
 }
 
@@ -126,6 +126,11 @@ function actualtime_startCount(task, time) {
 
 function actualtime_endCount(){
    clearInterval(timer);
+}
+
+function actualtime_fillCurrentTime(task, time) {
+   var timestr = actualtime_timeToText(time, 1);
+   $("[id^='actualtime_timer_" + task + "_']").text(timestr);
 }
 
 function actualtime_pressedButton(task, val) {

--- a/js/actualtime.js
+++ b/js/actualtime.js
@@ -147,12 +147,14 @@ function actualtime_pressedButton(task, val) {
                $("[id^='actualtime_button_" + task + "_1_']").attr('value', text_pause).attr('action', 'pause').css('background-color', 'orange').prop('disabled', false);
                $("[id^='actualtime_button_" + task + "_2_']").attr('action', 'end').css('background-color', 'red').prop('disabled', false);
                actualtime_showTimerPopup(result['ticket_id']);
+               $("[id^='actualtime_faclock_" + task + "_']").addClass('fa-clock-o').css('color', 'red');
                return;
             } else if ((val == 'end') || (val == 'pause')) {
                actualtime_endCount();
                $("#actualtime_popup").remove();
                // Update all forms of this task (normal and modal)
                $("[id^='actualtime_timer_" + task + "_']").css('color', 'black');
+               $("[id^='actualtime_faclock_" + task + "_']").css('color', 'black');
                var timestr = actualtime_timeToText(result['time'], 1);
                $("[id^='actualtime_timer_" + task + "_']").text(timestr);
                $("[id^='actualtime_segment_" + task + "_']").html(result['segment']);

--- a/setup.php
+++ b/setup.php
@@ -70,11 +70,7 @@ function plugin_init_actualtime() {
       // Add settings form as a tab on Setup - General page
       Plugin::registerClass('PluginActualtimeConfig', ['addtabon' => 'Config']);
 
-      // If settings disable timers, just don't load any hook
       $config = new PluginActualtimeConfig;
-      if (!$config->isEnabled()) {
-         return;
-      }
 
       $PLUGIN_HOOKS['post_item_form']['actualtime'] = ['PluginActualtimeTask', 'postForm'];
       $PLUGIN_HOOKS['show_item_stats']['actualtime'] = ['Ticket'=> 'plugin_activetime_item_stats'];

--- a/setup.php
+++ b/setup.php
@@ -86,5 +86,10 @@ function plugin_init_actualtime() {
          $PLUGIN_HOOKS['post_show_tab']['actualtime'] = ['PluginActualtimeTask', 'postShowTab'];
       }
 
+      if ($config->showTimerInBox()) {
+         // This hook is not needed if not showing closed task box timer
+         $PLUGIN_HOOKS['post_show_item']['actualtime'] = ['PluginActualtimeTask', 'postShowItem'];
+      }
+
    }
 }

--- a/setup.php
+++ b/setup.php
@@ -1,5 +1,5 @@
 <?php
-define ('PLUGIN_ACTUALTIME_VERSION', '1.1.2');
+define ('PLUGIN_ACTUALTIME_VERSION', '1.1.3');
 // Minimal GLPI version, inclusive
 define("PLUGIN_ACTUALTIME_MIN_GLPI", "9.3.0");
 // Maximum GLPI version, exclusive

--- a/tests/units/PluginActualtimeConfig.php
+++ b/tests/units/PluginActualtimeConfig.php
@@ -49,6 +49,13 @@ class PluginActualtimeConfig extends atoum {
                ->isFalse();
    }
 
+   public function testShowTimerInBox() {
+      $this
+         ->given($this->newTestedInstance)
+            ->boolean($this->testedInstance->showTimerInBox())
+               ->isTrue();
+   }
+
    public function testCanView() {
       $this
          ->given($this->newTestedInstance)

--- a/tests/units/PluginActualtimeConfig.php
+++ b/tests/units/PluginActualtimeConfig.php
@@ -28,13 +28,6 @@ class PluginActualtimeConfig extends atoum {
                ->isInstanceOfTestedClass();
    }
 
-   public function testIsEnabled() {
-      $this
-         ->given($this->newTestedInstance)
-            ->boolean($this->testedInstance->isEnabled())
-               ->isTrue();
-   }
-
    public function testShowTimerPopup() {
       $this
          ->given($this->newTestedInstance)

--- a/tests/units/PluginActualtimeConfig.php
+++ b/tests/units/PluginActualtimeConfig.php
@@ -42,6 +42,13 @@ class PluginActualtimeConfig extends atoum {
                ->isTrue();
    }
 
+   public function testShowInHelpdesk() {
+      $this
+         ->given($this->newTestedInstance)
+            ->boolean($this->testedInstance->showInHelpdesk())
+               ->isFalse();
+   }
+
    public function testCanView() {
       $this
          ->given($this->newTestedInstance)


### PR DESCRIPTION
This PR solves issue #35 , according to the finds of issue's discussion.

* Enable setting was removed (no use for it)
* Timer can be seen in task box when it is closed also (beside status checkbox), that can be disabled on setup page)
* A new setting disables (default) or enables the visibility of Actualtime times for user in Helpdesk interface (default show timers only in Standard interface)