### PR TITLE
Remove maximumNumberOfProcesses limitation to keep analysis fast on modern computers.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,4 @@
 parameters:
-    parallel:
-        maximumNumberOfProcesses: 2
     level: 5
     bootstrapFiles:
         - ../../inc/based_config.php


### PR DESCRIPTION
In CI PHPStan will automatically the maximum number of CPUs to use