### PR TITLE
3.2.6: enforce right check on running timers AJAX endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Actualtime
 
+## [3.2.6] - 2026/08/10
+### Fixed
+- ajax/running.php now requires the `plugin_actualtime_running` right, matching the check already enforced in front/running.php
+
 ## [3.2.5] - 2026/04/16
 ### Fixed
 - Project Task don't update time

--- a/ajax/running.php
+++ b/ajax/running.php
@@ -35,6 +35,7 @@ header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
 Session::checkLoginUser();
+Session::checkRight('plugin_actualtime_running', READ);
 
 if (isset($_POST["action"])) {
     echo PluginActualtimeRunning::listRunning();

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_ACTUALTIME_VERSION', '3.2.5');
+define('PLUGIN_ACTUALTIME_VERSION', '3.2.6');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ACTUALTIME_MIN_GLPI", "10.0.10");


### PR DESCRIPTION
## Summary
- `ajax/running.php` only checked for a logged-in session (`Session::checkLoginUser()`) and returned every user's running timers to any authenticated user. `front/running.php` already required `Session::checkRight('plugin_actualtime_running', READ)`; the AJAX endpoint now enforces the same check.
- Bumped plugin version to `3.2.6` and updated the changelog.

## Test plan
- [x] Confirmed on a test server that the AJAX endpoint now returns a 403/insufficient rights response for a profile without `plugin_actualtime_running`, and continues to work normally for a profile that has it.