### PR TITLE
Require plugin_actualtime_running right in ajax/running.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Actualtime
 
+## [4.1.2] - 2026/09/09
+### Fixed
+- Require the plugin_actualtime_running right in ajax/running.php, matching the check already enforced in front/running.php
+
 ## [4.1.1] - 2026/08/06
 ### Fixed
 - Actualtime Usage Card don't show correct dates

--- a/ajax/running.php
+++ b/ajax/running.php
@@ -35,6 +35,7 @@ header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
 Session::checkLoginUser();
+Session::checkRight('plugin_actualtime_running', READ);
 
 if (isset($_POST["action"])) {
     echo PluginActualtimeRunning::listRunning();

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_ACTUALTIME_VERSION', '4.1.1');
+define('PLUGIN_ACTUALTIME_VERSION', '4.1.2');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ACTUALTIME_MIN_GLPI", "11.0.0");


### PR DESCRIPTION
## Summary

`ajax/running.php` only checked that the user had a logged-in session (`Session::checkLoginUser()`) before returning the list of currently running timers for every user. `front/running.php` already requires `Session::checkRight('plugin_actualtime_running', READ)` to show the same data — the AJAX endpoint was an unguarded alternate path to it. This adds the same right check.

Version bumped from 4.0.1 to 4.0.2.

## Test plan

- [ ] Confirm a user without the `plugin_actualtime_running` right gets a rights error when calling `ajax/running.php` directly
- [ ] Confirm a user with the right still gets the running timers list as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)