### PR TITLE
ci: automate tag/release/marketplace-xml pipeline on merge to master

### DIFF
--- a/.github/workflows/auto-tag-new-version.yml
+++ b/.github/workflows/auto-tag-new-version.yml
@@ -1,0 +1,15 @@
+name: "Automatically tag new version"
+
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - "setup.php"
+
+jobs:
+  auto-tag-new-version:
+    name: "Automatically tag new version"
+    uses: "glpi-project/plugin-release-workflows/.github/workflows/auto-tag-new-version.yml@v1"
+    secrets:
+      github-token: "${{ secrets.AUTOTAG_TOKEN }}"

--- a/.github/workflows/publish-marketplace-xml.yml
+++ b/.github/workflows/publish-marketplace-xml.yml
@@ -1,0 +1,11 @@
+name: "Publish marketplace XML"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  call:
+    permissions:
+      contents: "write"
+    uses: "ticgal/.github/.github/workflows/publish-marketplace-xml.yml@main"

--- a/.github/workflows/publish-marketplace-xml.yml
+++ b/.github/workflows/publish-marketplace-xml.yml
@@ -8,4 +8,4 @@ jobs:
   call:
     permissions:
       contents: "write"
-    uses: "ticgal/.github/.github/workflows/publish-marketplace-xml.yml@main"
+    uses: "ticgal/.github/.github/workflows/publish-marketplace-xml.yml@master"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,13 @@
+name: "Publish release"
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish-release:
+    permissions:
+      contents: "write"
+    name: "Publish release"
+    uses: "glpi-project/plugin-release-workflows/.github/workflows/publish-release.yml@v1"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+/docs/plans


### PR DESCRIPTION
## Summary
- Adopts `glpi-project/plugin-release-workflows`' official `auto-tag-new-version` and `publish-release` reusable workflows, so merging a version-bump PR to `master` automatically tags and publishes the GitHub Release (currently done by hand).
- Adds a `publish-marketplace-xml` workflow that calls a new shared `ticgal/.github` reusable workflow to append the new `<version>` entry to `multimedia/actualtime.xml` once the release is published (currently a manual edit).

## Requires (follow-up, not in this PR)
- [ ] `ticgal/.github` repo created with the shared `publish-marketplace-xml.yml` reusable workflow.
- [ ] Repo secret `AUTOTAG_TOKEN`: a PAT with `contents: read/write`, needed because a tag pushed with the default `GITHUB_TOKEN` won't itself trigger the next workflow.

## Test plan
- [ ] Merge a throwaway version bump through this pipeline end-to-end and confirm: tag created → release published with tarball → `multimedia/actualtime.xml` gets the new `<version>` block.
- [ ] Re-trigger to confirm the XML step skips a duplicate insert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)